### PR TITLE
Export: add context menu and batch operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img src="https://raw.githubusercontent.com/apostrophecms/apostrophe/main/logo.svg" alt="ApostropheCMS logo" width="80" height="80">
 
-  <h1>Apostrophe Module Template</h1>
+  <h1>Apostrophe Import Export Module</h1>
   <p>
     <a aria-label="Apostrophe logo" href="https://v3.docs.apostrophecms.org">
       <img src="https://img.shields.io/badge/MADE%20FOR%20Apostrophe%203-000000.svg?style=for-the-badge&logo=Apostrophe&labelColor=6516dd">

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,0 +1,4 @@
+{
+  "export": "Export",
+  "exporting": "Exporting"
+}

--- a/index.js
+++ b/index.js
@@ -5,7 +5,15 @@ module.exports = {
   bundle: {
     directory: 'modules',
     modules: getBundleModuleNames()
-  }
+  },
+
+  options: {
+    name: '@apostrophecms/import-export',
+    i18n: {
+      ns: 'aposImportExport',
+      browser: true
+    },
+  },
 };
 
 function getBundleModuleNames() {

--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ module.exports = {
     i18n: {
       ns: 'aposImportExport',
       browser: true
-    },
-  },
+    }
+  }
 };
 
 function getBundleModuleNames() {

--- a/modules/@apostrophecms/import-export-doc-type/index.js
+++ b/modules/@apostrophecms/import-export-doc-type/index.js
@@ -4,14 +4,6 @@ module.exports = {
   improve: '@apostrophecms/doc-type',
 
   init(self) {
-    if (self.options.export === false) {
-      excludedTypes.push({
-        type: {
-          $ne: self.__meta.name
-        }
-      });
-    }
-
     const criteria = {
       action: 'export',
       context: 'update',
@@ -19,7 +11,10 @@ module.exports = {
       modal: 'AposExportPiecesModal'
     };
 
-    if (excludedTypes.length) {
+    if (self.options.export === false) {
+      excludedTypes.push({
+        type: { $ne: self.__meta.name }
+      });
       criteria.if = { $and: excludedTypes };
     }
 

--- a/modules/@apostrophecms/import-export-doc-type/index.js
+++ b/modules/@apostrophecms/import-export-doc-type/index.js
@@ -1,16 +1,28 @@
+const excludedTypes = [];
+
 module.exports = {
   improve: '@apostrophecms/doc-type',
 
   init(self) {
     if (self.options.export === false) {
-      return;
+      excludedTypes.push({
+        type: {
+          $ne: self.__meta.name
+        }
+      });
     }
 
-    self.apos.doc.addContextOperation(self.__meta.name, {
+    const criteria = {
       action: 'export',
       context: 'update',
       label: 'aposImportExport:export',
-      modal: 'AposExportPiecesModal',
-    });
-  },
-}
+      modal: 'AposExportPiecesModal'
+    };
+
+    if (excludedTypes.length) {
+      criteria.if = { $and: excludedTypes };
+    }
+
+    self.apos.doc.addContextOperation(self.__meta.name, criteria);
+  }
+};

--- a/modules/@apostrophecms/import-export-doc-type/index.js
+++ b/modules/@apostrophecms/import-export-doc-type/index.js
@@ -1,0 +1,16 @@
+module.exports = {
+  improve: '@apostrophecms/doc-type',
+
+  init(self) {
+    if (self.options.export === false) {
+      return;
+    }
+
+    self.apos.doc.addContextOperation(self.__meta.name, {
+      action: 'export',
+      context: 'update',
+      label: 'aposImportExport:export',
+      modal: 'AposExportPiecesModal',
+    });
+  },
+}

--- a/modules/@apostrophecms/import-export-doc-type/index.js
+++ b/modules/@apostrophecms/import-export-doc-type/index.js
@@ -13,9 +13,13 @@ module.exports = {
 
     if (self.options.export === false) {
       excludedTypes.push({
-        type: { $ne: self.__meta.name }
+        type: {
+          $ne: self.__meta.name
+        }
       });
-      criteria.if = { $and: excludedTypes };
+      criteria.if = {
+        $and: excludedTypes
+      };
     }
 
     self.apos.doc.addContextOperation(self.__meta.name, criteria);

--- a/modules/@apostrophecms/import-export-piece-type/index.js
+++ b/modules/@apostrophecms/import-export-piece-type/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   improve: '@apostrophecms/piece-type',
 
-  cascades: ['batchOperations'],
+  cascades: [ 'batchOperations' ],
 
   batchOperations(self) {
     if (self.options.export === false) {
@@ -15,7 +15,7 @@ module.exports = {
           messages: {
             progress: 'aposImportExport:exporting'
           },
-          modal: 'AposExportPiecesModal',
+          modal: 'AposExportPiecesModal'
         }
       },
       group: {
@@ -24,6 +24,6 @@ module.exports = {
           operations: [ 'export' ]
         }
       }
-    }
-  },
-}
+    };
+  }
+};

--- a/modules/@apostrophecms/import-export-piece-type/index.js
+++ b/modules/@apostrophecms/import-export-piece-type/index.js
@@ -1,0 +1,29 @@
+module.exports = {
+  improve: '@apostrophecms/piece-type',
+
+  cascades: ['batchOperations'],
+
+  batchOperations(self) {
+    if (self.options.export === false) {
+      return;
+    }
+
+    return {
+      add: {
+        export: {
+          label: 'aposImportExport:export',
+          messages: {
+            progress: 'aposImportExport:exporting'
+          },
+          modal: 'AposExportPiecesModal',
+        }
+      },
+      group: {
+        more: {
+          icon: 'dots-vertical-icon',
+          operations: [ 'export' ]
+        }
+      }
+    }
+  },
+}


### PR DESCRIPTION
Add `Export` buttons for documents contextual menus and batch operations.

https://linear.app/apostrophecms/issue/PRO-4258/as-an-editor-i-can-see-a-download-button-in-docs-contextual-menus-and

## Acceptance Criteria

A Download button is available from documents contextual menus.

A Download button is available from pieces batch operations.

If the option shareDocsDisableExport is true, these buttons must not appear for this module.

