### PR TITLE
Pro 4260 export modal

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6,6 +6,7 @@
   "exportModalSettingsLabel": "Export Settings",
   "exportModalDocumentFormat": "Document Format",
   "exportModalIncludeRelated": "Include related documents",
+  "exportModalIncludeChildren": "Include children of this page",
   "exportModalIncludeRelatedSettings": "Related Documents Settings",
   "exportModalNoRelatedTypes": "No Related Types"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2,7 +2,7 @@
   "export": "Export",
   "exporting": "Exporting",
   "exportModalDescription": "You've selected {{ count }} {{ type }} for export",
-  "exportModalRelatedDocumentDescription": "Include the following document types\nwhere applicable",
+  "exportModalRelatedDocumentDescription": "Include the following document types where applicable",
   "exportModalSettingsLabel": "Export Settings",
   "exportModalDocumentFormat": "Document Format",
   "exportModalIncludeRelated": "Include related documents",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,5 +1,11 @@
 {
   "export": "Export",
   "exporting": "Exporting",
-  "exportModalDescription": "You've selected {{ count }} {{ type }} for export"
+  "exportModalDescription": "You've selected {{ count }} {{ type }} for export",
+  "exportModalRelatedDocumentDescription": "Include the following document types\nwhere applicable",
+  "exportModalSettingsLabel": "Export Settings",
+  "exportModalDocumentFormat": "Document Format",
+  "exportModalIncludeRelated": "Include related documents",
+  "exportModalIncludeRelatedSettings": "Related Documents Settings",
+  "exportModalNoRelatedTypes": "No Related Types"
 }

--- a/index.js
+++ b/index.js
@@ -27,12 +27,12 @@ module.exports = {
             throw self.apos.error('forbidden');
           }
 
-          const moduleName = self.apos.launder.string(req.query.moduleName);
-          if (!moduleName) {
+          const type = self.apos.launder.string(req.query.type);
+          if (!type) {
             throw self.apos.error('invalid');
           }
 
-          const { schema = [] } = self.apos.modules[moduleName];
+          const { schema = [] } = self.apos.modules[type];
           const relatedTypes = schema.flatMap(searchRelationships).filter(Boolean);
 
           return [ ...new Set(relatedTypes) ];

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = {
             throw self.apos.error('invalid');
           }
 
-          const { schema } = self.apos.modules[moduleName];
+          const { schema = [] } = self.apos.modules[moduleName];
           const relatedTypes = schema.flatMap(searchRelationships).filter(Boolean);
 
           return [ ...new Set(relatedTypes) ];
@@ -44,7 +44,7 @@ module.exports = {
               return obj.schema.flatMap(searchRelationships);
             } else if (obj.type === 'area') {
               return Object.keys(obj.options.widgets).flatMap(widget => {
-                const schema = self.apos.modules[`${widget}-widget`]?.schema || [];
+                const { schema = [] } = self.apos.modules[`${widget}-widget`];
                 return schema.map(searchRelationships);
               });
             }

--- a/index.js
+++ b/index.js
@@ -13,6 +13,46 @@ module.exports = {
       ns: 'aposImportExport',
       browser: true
     }
+  },
+
+  apiRoutes(self) {
+    return {
+      get: {
+        async related(req) {
+          if (!req.user) {
+            throw self.apos.error('forbidden');
+          }
+          const moduleName = self.apos.launder.string(req.query.moduleName);
+          if (!moduleName) {
+            return { success: false };
+          }
+          const schema = self.apos.modules[moduleName].schema;
+
+          const relatedTypes = schema.reduce((acc, cur) => {
+            if (cur.type === 'relationship') {
+              acc.push(cur.withType);
+            } else if (cur.type === 'array' || cur.type === 'object') {
+              for (const field of cur.schema) {
+                if (field.type === 'relationship') {
+                  acc.push(field.withType);
+                }
+              }
+              // } else if (cur.type === 'area') {
+
+            }
+
+            return acc;
+          }, []);
+
+          console.log('relatedTypes', require('util').inspect([ ...new Set(relatedTypes) ], {
+            colors: true,
+            depth: 1
+          }));
+
+          return { success: true };
+        }
+      }
+    };
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = {
           }
           const schema = self.apos.modules[moduleName].schema;
 
-          const relatedTypes = schema.reduce((acc, cur) => {
+          return [ ...new Set(schema.reduce((acc, cur) => {
             if (cur.type === 'relationship') {
               acc.push(cur.withType);
             } else if (cur.type === 'array' || cur.type === 'object') {
@@ -42,14 +42,7 @@ module.exports = {
             }
 
             return acc;
-          }, []);
-
-          console.log('relatedTypes', require('util').inspect([ ...new Set(relatedTypes) ], {
-            colors: true,
-            depth: 1
-          }));
-
-          return { success: true };
+          }, [])) ];
         }
       }
     };

--- a/modules/@apostrophecms/import-export-doc-type/index.js
+++ b/modules/@apostrophecms/import-export-doc-type/index.js
@@ -8,7 +8,7 @@ module.exports = {
       action: 'export',
       context: 'update',
       label: 'aposImportExport:export',
-      modal: 'AposExportPiecesModal'
+      modal: 'AposExportModal'
     };
 
     if (self.options.export === false) {

--- a/modules/@apostrophecms/import-export-piece-type/index.js
+++ b/modules/@apostrophecms/import-export-piece-type/index.js
@@ -15,7 +15,7 @@ module.exports = {
           messages: {
             progress: 'aposImportExport:exporting'
           },
-          modal: 'AposExportPiecesModal'
+          modal: 'AposExportModal'
         }
       },
       group: {

--- a/ui/apos/components/AposExportModal.vue
+++ b/ui/apos/components/AposExportModal.vue
@@ -2,7 +2,7 @@
   <AposModal
     :modal="modal"
     class="apos-export"
-    v-on="{ esc: cancel }"
+    @esc="cancel"
     @no-modal="$emit('safe-close')"
     @inactive="modal.active = false"
     @show-modal="modal.showModal = true"
@@ -224,6 +224,7 @@ export default {
 
 ::v-deep .apos-modal__body {
   padding: 20px 30px;
+  width: 335px;
 }
 
 ::v-deep .apos-modal__body-main {
@@ -260,7 +261,7 @@ export default {
   display: flex;
   flex-direction: column;
   align-items: baseline;
-  min-width: 325px;
+  min-width: 100%;
   font-size: var(--a-type-large);
 }
 
@@ -303,10 +304,6 @@ export default {
   align-items: baseline;
   height: auto;
   margin-bottom: 20px;
-}
-
-.apos-export__related-description {
-  white-space: pre-line;
 }
 
 .apos-export__separator {

--- a/ui/apos/components/AposExportModal.vue
+++ b/ui/apos/components/AposExportModal.vue
@@ -22,7 +22,7 @@
           <div class="apos-export-pieces__settings">
             Export settings
           </div>
-          <div class="apos-export-pieces__separator"></div>
+          <div class="apos-export-pieces__separator" />
           <div class="apos-export-pieces__settings-row apos-export-pieces__settings-row--red-colored">
             <div>Document format</div>
             <AposContextMenu
@@ -39,9 +39,13 @@
           </div>
           <div class="apos-export-pieces__settings-row">
             <div>Include related documents</div>
-            <AposToggle v-model="unrelatedDocumentsDisabled" />
+            <AposToggle
+              v-model="relatedDocumentsDisabled"
+              class="apos-export-pieces__toggle"
+              @toggle="toggleRelatedDocuments"
+            />
           </div>
-          <div class="apos-export-pieces__separator apos-export-pieces__separator--full-width"></div>
+          <div class="apos-export-pieces__separator apos-export-pieces__separator--full-width" />
 
           <div class="apos-export-pieces__btns">
             <AposButton
@@ -50,11 +54,11 @@
               @click="cancel"
             />
             <AposButton
-              ref="exportPieces"
+              ref="exportDocs"
               class="apos-export-pieces__btn"
               label="aposImportExport:export"
               type="primary"
-              @click="exportPieces"
+              @click="exportDocs"
             />
           </div>
         </template>
@@ -86,7 +90,7 @@ export default {
         disableHeader: true
       },
       formValues: null,
-      unrelatedDocumentsDisabled: true
+      relatedDocumentsDisabled: true
     };
   },
 
@@ -104,9 +108,9 @@ export default {
 
   methods: {
     ready() {
-      this.$refs.exportPieces.$el.querySelector('button').focus();
+      this.$refs.exportDocs.$el.querySelector('button').focus();
     },
-    exportPieces() {
+    exportDocs() {
       this.modal.showModal = false;
       const result = true;
       this.$emit('modal-result', result);
@@ -114,6 +118,9 @@ export default {
     async cancel() {
       this.modal.showModal = false;
       this.$emit('modal-result', false);
+    },
+    toggleRelatedDocuments() {
+      this.relatedDocumentsDisabled = !this.relatedDocumentsDisabled;
     }
   }
 };
@@ -162,6 +169,10 @@ export default {
   background-color: var(--a-danger);
   color: var(--a-text-primary);
   border: 1px solid var(--a-text-primary);
+}
+
+::v-deep .apos-toggle__slider:before {
+  left: 4px;
 }
 
 .apos-export-pieces__heading {

--- a/ui/apos/components/AposExportModal.vue
+++ b/ui/apos/components/AposExportModal.vue
@@ -25,17 +25,31 @@
               {{ $t('aposImportExport:exportModalSettingsLabel') }}
             </div>
             <div class="apos-export__separator" />
-            <div class="apos-export__settings-row apos-export__settings-row--red-colored">
+
+            <div class="apos-export__settings-row">
               <div>{{ $t('aposImportExport:exportModalDocumentFormat') }}</div>
               <AposContextMenu
                 disabled
                 :button="{
                   label: 'ZIP',
                   icon: 'chevron-down-icon',
-                  modifiers: ['icon-right', 'disabled', 'export-format']
+                  modifiers: ['icon-right', 'disabled']
                 }"
               />
             </div>
+
+            <div
+              v-if="moduleName === '@apostrophecms/page'"
+              class="apos-export__settings-row"
+            >
+              <div>{{ $t('aposImportExport:exportModalIncludeChildren') }}</div>
+              <AposToggle
+                v-model="relatedChildrenDisabled"
+                class="apos-export__toggle"
+                @toggle="toggleRelatedChildren"
+              />
+            </div>
+
             <div class="apos-export__settings-row">
               <div>{{ $t('aposImportExport:exportModalIncludeRelated') }}</div>
               <AposToggle
@@ -128,8 +142,10 @@ export default {
       },
       formValues: null,
       relatedDocumentsDisabled: true,
+      relatedChildrenDisabled: true,
       relatedTypes: null,
-      checkedRelatedTypes: []
+      checkedRelatedTypes: [],
+      type: this.moduleName
     };
   },
 
@@ -152,6 +168,10 @@ export default {
 
   async mounted() {
     this.modal.active = true;
+
+    if (this.type === '@apostrophecms/page') {
+      this.type = this.$attrs.doc?.type;
+    }
   },
 
   methods: {
@@ -174,10 +194,13 @@ export default {
         this.relatedTypes = await window.apos.http.get('/api/v1/@apostrophecms/import-export/related', {
           busy: true,
           qs: {
-            moduleName: this.moduleName
+            type: this.type
           }
         });
       }
+    },
+    toggleRelatedChildren() {
+      this.relatedChildrenDisabled = !this.relatedChildrenDisabled;
     },
     checkRelatedTypes(evt) {
       if (evt.target.checked) {
@@ -233,12 +256,6 @@ export default {
   align-items: baseline;
 }
 
-::v-deep .apos-button.apos-button--export-format {
-  background-color: var(--a-danger);
-  color: var(--a-text-primary);
-  border: 1px solid var(--a-text-primary);
-}
-
 ::v-deep .apos-toggle__slider {
   display: flex;
 }
@@ -280,22 +297,6 @@ export default {
   gap: 70px;
   height: 43px;
   width: 100%;
-}
-
-.apos-export__settings-row--red-colored {
-  background-color: var(--a-danger);
-  opacity: 0.5;
-  position: relative;
-
-  &::before {
-    content: "";
-    background-color: var(--a-danger);
-    position: absolute;
-    height: 100%;
-    width: 110%;
-    left: -5%;
-    z-index: -1;
-  }
 }
 
 .apos-export__settings-row--column {

--- a/ui/apos/components/AposExportModal.vue
+++ b/ui/apos/components/AposExportModal.vue
@@ -22,25 +22,22 @@
 
           <div class="apos-export__section">
             <div class="apos-export__settings">
-              Export Settings
+              {{ $t('aposImportExport:exportModalSettingsLabel') }}
             </div>
             <div class="apos-export__separator" />
             <div class="apos-export__settings-row apos-export__settings-row--red-colored">
-              <div>Document format</div>
+              <div>{{ $t('aposImportExport:exportModalDocumentFormat') }}</div>
               <AposContextMenu
-                :menu="[{
-                  label: 'JSONP',
-                  modifiers: ['selected', 'disabled']
-                }]"
+                disabled
                 :button="{
-                  label: 'JSONP',
+                  label: 'ZIP',
                   icon: 'chevron-down-icon',
-                  modifiers: ['icon-right', 'disabled', 'export-pieces-format']
+                  modifiers: ['icon-right', 'disabled', 'export-format']
                 }"
               />
             </div>
             <div class="apos-export__settings-row">
-              <div>Include related documents</div>
+              <div>{{ $t('aposImportExport:exportModalIncludeRelated') }}</div>
               <AposToggle
                 v-model="relatedDocumentsDisabled"
                 class="apos-export__toggle"
@@ -54,11 +51,13 @@
             class="apos-export__section"
           >
             <div class="apos-export__settings">
-              Related Documents Settings
+              {{ $t('aposImportExport:exportModalIncludeRelatedSettings') }}
             </div>
             <div class="apos-export__separator" />
             <div class="apos-export__settings-row apos-export__settings-row--column">
-              <div>Include the following document types</div>
+              <div class="apos-export__related-description">
+                {{ $t('aposImportExport:exportModalRelatedDocumentDescription') }}
+              </div>
               <div v-if="relatedTypes && relatedTypes.length">
                 <AposCheckbox
                   v-for="relatedType in relatedTypes"
@@ -67,17 +66,17 @@
                   tabindex="-1"
                   :choice="{
                     value: relatedType,
-                    label: relatedType
+                    label: getRelatedTypeLabel(relatedType)
                   }"
                   :field="{
-                    label: relatedType,
+                    label: getRelatedTypeLabel(relatedType),
                     name: relatedType
                   }"
                   @updated="checkRelatedTypes"
                 />
               </div>
               <div v-else>
-                No Types
+                {{ $t('aposImportExport:exportModalNoRelatedTypes') }}
               </div>
             </div>
           </div>
@@ -139,14 +138,8 @@ export default {
       const label = this.count > 1 ? moduleOptions.pluralLabel : moduleOptions.label;
       return this.$t(label).toLowerCase();
     },
-
-    checkedProxy: {
-      get() {
-        return this.checkedRelatedTypes;
-      },
-      set(val) {
-        this.$emit('change', val);
-      }
+    checkedProxy() {
+      return this.checkedRelatedTypes;
     }
   },
 
@@ -171,7 +164,7 @@ export default {
       this.relatedDocumentsDisabled = !this.relatedDocumentsDisabled;
 
       if (!this.relatedDocumentsDisabled && !Array.isArray(this.relatedTypes)) {
-        this.relatedTypes = await apos.http.get('/api/v1/@apostrophecms/import-export/related', {
+        this.relatedTypes = await window.apos.http.get('/api/v1/@apostrophecms/import-export/related', {
           busy: true,
           qs: {
             moduleName: this.moduleName
@@ -185,6 +178,10 @@ export default {
       } else {
         this.checkedRelatedTypes = this.checkedRelatedTypes.filter(relatedType => relatedType !== evt.target.value);
       }
+    },
+    getRelatedTypeLabel(moduleName) {
+      const moduleOptions = window.apos.modules[moduleName];
+      return this.$t(moduleOptions.label);
     }
   }
 };
@@ -219,7 +216,7 @@ export default {
 }
 
 ::v-deep .apos-modal__body {
-  padding: 20px 35px;
+  padding: 20px 30px;
 }
 
 ::v-deep .apos-modal__body-main {
@@ -228,7 +225,7 @@ export default {
   align-items: baseline;
 }
 
-::v-deep .apos-button.apos-button--export-pieces-format {
+::v-deep .apos-button.apos-button--export-format {
   background-color: var(--a-danger);
   color: var(--a-text-primary);
   border: 1px solid var(--a-text-primary);
@@ -256,7 +253,7 @@ export default {
   display: flex;
   flex-direction: column;
   align-items: baseline;
-  min-width: 340px;
+  min-width: 325px;
   font-size: var(--a-type-large);
 }
 
@@ -301,6 +298,10 @@ export default {
   margin-bottom: 20px;
 }
 
+.apos-export__related-description {
+  white-space: pre-line;
+}
+
 .apos-export__separator {
   background-color: var(--a-base-8);
   position: relative;
@@ -314,8 +315,9 @@ export default {
   background-color: var(--a-base-8);
   position: absolute;
   height: 100%;
-  width: 120%;
-  left: -10%;
+  width: calc(100% + 60px);
+  left: -30px;
+  right: 0;
 }
 
 ::v-deep .apos-schema .apos-field {

--- a/ui/apos/components/AposExportModal.vue
+++ b/ui/apos/components/AposExportModal.vue
@@ -91,6 +91,7 @@
             />
             <AposButton
               ref="exportDocs"
+              icon="apos-import-export-download-icon"
               class="apos-export__btn"
               label="aposImportExport:export"
               type="primary"
@@ -169,7 +170,7 @@ export default {
     async toggleRelatedDocuments() {
       this.relatedDocumentsDisabled = !this.relatedDocumentsDisabled;
 
-      if (!this.relatedDocumentsDisabled && !Array.isArray(this.relatedTypes)) {
+      if (!this.relatedDocumentsDisabled && this.relatedTypes === null) {
         this.relatedTypes = await window.apos.http.get('/api/v1/@apostrophecms/import-export/related', {
           busy: true,
           qs: {

--- a/ui/apos/components/AposExportModal.vue
+++ b/ui/apos/components/AposExportModal.vue
@@ -116,7 +116,7 @@ export default {
     }
   },
 
-  emits: [ 'safe-close', 'modal-result' ],
+  emits: [ 'change', 'safe-close', 'modal-result' ],
 
   data() {
     return {
@@ -138,8 +138,14 @@ export default {
       const label = this.count > 1 ? moduleOptions.pluralLabel : moduleOptions.label;
       return this.$t(label).toLowerCase();
     },
-    checkedProxy() {
-      return this.checkedRelatedTypes;
+
+    checkedProxy: {
+      get() {
+        return this.checkedRelatedTypes;
+      },
+      set(val) {
+        this.$emit('change', val);
+      }
     }
   },
 

--- a/ui/apos/components/AposExportPiecesModal.vue
+++ b/ui/apos/components/AposExportPiecesModal.vue
@@ -19,6 +19,30 @@
           >
             {{ $t('aposImportExport:exportModalDescription', { count, type: moduleLabel }) }}
           </p>
+          <div class="apos-export-pieces__settings">
+            Export settings
+          </div>
+          <div class="apos-export-pieces__separator"></div>
+          <div class="apos-export-pieces__settings-row apos-export-pieces__settings-row--red-colored">
+            <div>Document format</div>
+            <AposContextMenu
+              :menu="[{
+                label: 'JSONP',
+                modifiers: ['selected', 'disabled']
+              }]"
+              :button="{
+                label: 'JSONP',
+                icon: 'chevron-down-icon',
+                modifiers: ['icon-right', 'disabled', 'export-pieces-format']
+              }"
+            />
+          </div>
+          <div class="apos-export-pieces__settings-row">
+            <div>Include related documents</div>
+            <AposToggle v-model="unrelatedDocumentsDisabled" />
+          </div>
+          <div class="apos-export-pieces__separator apos-export-pieces__separator--full-width"></div>
+
           <div class="apos-export-pieces__btns">
             <AposButton
               class="apos-export-pieces__btn"
@@ -61,7 +85,8 @@ export default {
         showModal: false,
         disableHeader: true
       },
-      formValues: null
+      formValues: null,
+      unrelatedDocumentsDisabled: true
     };
   },
 
@@ -124,13 +149,19 @@ export default {
 }
 
 ::v-deep .apos-modal__body {
-  padding: 60px;
+  padding: 30px;
 }
 
 ::v-deep .apos-modal__body-main {
   display: flex;
   flex-direction: column;
   align-items: baseline;
+}
+
+::v-deep .apos-button.apos-button--export-pieces-format {
+  background-color: var(--a-danger);
+  color: var(--a-text-primary);
+  border: 1px solid var(--a-text-primary);
 }
 
 .apos-export-pieces__heading {
@@ -142,8 +173,57 @@ export default {
 
 .apos-export-pieces__description {
   @include type-base;
+  font-size: var(--a-type-large);
   max-width: 370px;
   line-height: var(--a-line-tallest);
+}
+
+.apos-export-pieces__settings {
+  font-size: var(--a-type-large);
+  font-weight: 600;
+  color: var(--a-base-3);
+  margin-top: 20px;
+}
+
+.apos-export-pieces__settings-row {
+  font-size: var(--a-type-large);
+  display: flex;
+  align-items: center;
+  gap: 70px;
+  height: 43px;
+}
+
+.apos-export-pieces__settings-row--red-colored {
+  background-color: var(--a-danger);
+  opacity: 0.5;
+  position: relative;
+
+  &::before {
+    content: "";
+    background-color: var(--a-danger);
+    position: absolute;
+    height: 100%;
+    width: 110%;
+    left: -5%;
+    z-index: -1;
+  }
+}
+
+.apos-export-pieces__separator {
+  background-color: var(--a-base-8);
+  position: relative;
+  height: 1px;
+  width: 100%;
+  margin: 10px 0;
+}
+
+.apos-export-pieces__separator--full-width::before {
+  content: "";
+  background-color: var(--a-base-8);
+  position: absolute;
+  height: 100%;
+  width: 120%;
+  left: -10%;
 }
 
 ::v-deep .apos-schema .apos-field {


### PR DESCRIPTION
https://linear.app/apostrophecms/issue/PRO-4260/as-an-editor-a-download-modal-is-opened-when-i-click-on-the-download

## Summary

As an editor, an export modal is opened when I click on the export button.

## What are the specific steps to test this change?

- When clicking on the Download button in contextual menu, this modal opens.
- When clicking on the Download button in batch operation, this modal opens.
- When clicking on the include related documents switcher I see a new section containing the types of the related docs and how many of each one might be exported if checked.
- The modal must show the name of the type of document that the user will export.
- The modal must request the relate method from the schema module to get related docs and show checkboxes as shown in the designs (without the amount for each one).
