### PR TITLE
filter types that have the relatedDocument option set to false

### DIFF
--- a/lib/apiRoutes.js
+++ b/lib/apiRoutes.js
@@ -33,11 +33,11 @@ module.exports = self => {
           const shouldRecurse = recursions <= maxRecursions;
 
           if (obj.type === 'relationship') {
-            // Filter out types that has the `relatedDocument` option set to `false` in their module.
+            // Filter out types that have the `relatedDocument` option set to `false` in their module.
             // Use `default-page` because this option is set on the page-type module,
             // which does not actually exist inside `apos.modules`:
             const module = obj.withType === '@apostrophecms/page'
-              ? 'default-page'
+              ? 'home-page'
               : obj.withType;
 
             return self.apos.modules[module].options.relatedDocument === false && obj.withType;

--- a/lib/apiRoutes.js
+++ b/lib/apiRoutes.js
@@ -28,13 +28,19 @@ module.exports = self => {
 
         return [ ...new Set(relatedTypes) ];
 
-        // TODO: do not include types that have the `relatedDocument = false`
         // option in their module configuration
         function searchRelationships(obj) {
           const shouldRecurse = recursions <= maxRecursions;
 
           if (obj.type === 'relationship') {
-            return obj.withType;
+            // Filter out types that has the `relatedDocument` option set to `false` in their module.
+            // Use `default-page` because this option is set on the page-type module,
+            // which does not actually exist inside `apos.modules`:
+            const module = obj.withType === '@apostrophecms/page'
+              ? 'default-page'
+              : obj.withType;
+
+            return self.apos.modules[module].options.relatedDocument === false && obj.withType;
           } else if (obj.type === 'array' || obj.type === 'object') {
             recursions++;
             return shouldRecurse && obj.schema.flatMap(searchRelationships);

--- a/lib/apiRoutes.js
+++ b/lib/apiRoutes.js
@@ -31,16 +31,10 @@ module.exports = self => {
         // option in their module configuration
         function searchRelationships(obj) {
           const shouldRecurse = recursions <= maxRecursions;
+          const shouldInclude = self.apos.modules[obj.withType]?.options.relatedDocument !== false;
 
           if (obj.type === 'relationship') {
-            // Filter out types that have the `relatedDocument` option set to `false` in their module.
-            // Use `home-page` because this option is set on the page-type module,
-            // which does not actually exist inside `apos.modules`:
-            const module = obj.withType === '@apostrophecms/page'
-              ? 'home-page'
-              : obj.withType;
-
-            return self.apos.modules[module].options.relatedDocument === false && obj.withType;
+            return shouldInclude && obj.withType;
           } else if (obj.type === 'array' || obj.type === 'object') {
             recursions++;
             return shouldRecurse && obj.schema.flatMap(searchRelationships);

--- a/lib/apiRoutes.js
+++ b/lib/apiRoutes.js
@@ -34,7 +34,7 @@ module.exports = self => {
 
           if (obj.type === 'relationship') {
             // Filter out types that have the `relatedDocument` option set to `false` in their module.
-            // Use `default-page` because this option is set on the page-type module,
+            // Use `home-page` because this option is set on the page-type module,
             // which does not actually exist inside `apos.modules`:
             const module = obj.withType === '@apostrophecms/page'
               ? 'home-page'

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -164,7 +164,7 @@ module.exports = self => {
       // never be considered "related" to other pages simply because
       // of navigation links, the feature is meant for pieces that feel more like
       // part of the document being localized)
-      return related.filter(doc => self.apos.modules[doc.type].relatedDocument !== false);
+      return related.filter(doc => self.apos.modules[doc.type].options.relatedDocument !== false);
     }
   };
 };


### PR DESCRIPTION
and fix an existing line that was missing `.options`

With data-set module having the `relatedDocument` option set to `false`:

```js
// in testbed, modules/@apostrophecms-pro/data-set/index.js
module.exports = {
  options: {
    relatedDocument: false
  }
};
```

_The `page-type` module has the option set to `false` in the core by default._

| before | after |
|--------|--------|
| <img width="427" alt="image" src="https://github.com/apostrophecms/import-export/assets/8301962/6b7d6003-3d24-4dfa-973c-6a3bedcf3599"> | <img width="426" alt="image" src="https://github.com/apostrophecms/import-export/assets/8301962/d17e1375-fcc3-46d9-8cef-d5e9e5e0df3c"> | 