### PR TITLE
handle permissions

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,12 +20,8 @@ module.exports = {
   },
 
   init(self) {
-    if (self.options.export !== false) {
-      self.apos.asset.iconMap['apos-import-export-download-icon'] = 'Download';
-    }
-    if (self.options.import !== false) {
-      self.apos.asset.iconMap['apos-import-export-upload-icon'] = 'Upload';
-    }
+    self.apos.asset.iconMap['apos-import-export-download-icon'] = 'Download';
+    self.apos.asset.iconMap['apos-import-export-upload-icon'] = 'Upload';
 
     self.exportFormats = {
       zip,

--- a/lib/apiRoutes.js
+++ b/lib/apiRoutes.js
@@ -28,8 +28,6 @@ module.exports = self => {
 
         return [ ...new Set(relatedTypes) ];
 
-        // TODO: do not include types that have the `relatedDocument = false`
-        // option in their module configuration
         function searchRelationships(obj) {
           const shouldRecurse = recursions <= maxRecursions;
           const shouldInclude = self.apos.modules[obj.withType] &&

--- a/lib/apiRoutes.js
+++ b/lib/apiRoutes.js
@@ -32,6 +32,7 @@ module.exports = self => {
           const shouldRecurse = recursions <= maxRecursions;
 
           if (obj.type === 'relationship') {
+            // TODO: handle permission here: exclude types that the user cannot access to:
             return self.canExport(obj.withType) && obj.withType;
           } else if (obj.type === 'array' || obj.type === 'object') {
             recursions++;

--- a/lib/apiRoutes.js
+++ b/lib/apiRoutes.js
@@ -1,5 +1,5 @@
 module.exports = self => {
-  if (self.options.export === false) {
+  if (self.options.importExport?.export === false) {
     return {};
   }
 

--- a/lib/apiRoutes.js
+++ b/lib/apiRoutes.js
@@ -32,7 +32,7 @@ module.exports = self => {
         // option in their module configuration
         function searchRelationships(obj) {
           const shouldRecurse = recursions <= maxRecursions;
-          const shouldInclude = self.apos.modules[obj.withType] &
+          const shouldInclude = self.apos.modules[obj.withType] &&
              self.apos.modules[obj.withType].options.export !== false;
 
           if (obj.type === 'relationship') {

--- a/lib/apiRoutes.js
+++ b/lib/apiRoutes.js
@@ -32,7 +32,7 @@ module.exports = self => {
           const shouldRecurse = recursions <= maxRecursions;
 
           if (obj.type === 'relationship') {
-            return self.canExport(req, obj.withType) && obj.withType;
+            return self.canExport(obj.withType) && obj.withType;
           } else if (obj.type === 'array' || obj.type === 'object') {
             recursions++;
             return shouldRecurse && obj.schema.flatMap(searchRelationships);

--- a/lib/apiRoutes.js
+++ b/lib/apiRoutes.js
@@ -32,7 +32,7 @@ module.exports = self => {
           const shouldRecurse = recursions <= maxRecursions;
 
           if (obj.type === 'relationship') {
-            return self.canExportDoc(req, obj.withType) && obj.withType;
+            return self.canExport(req, obj.withType) && obj.withType;
           } else if (obj.type === 'array' || obj.type === 'object') {
             recursions++;
             return shouldRecurse && obj.schema.flatMap(searchRelationships);

--- a/lib/apiRoutes.js
+++ b/lib/apiRoutes.js
@@ -30,11 +30,9 @@ module.exports = self => {
 
         function searchRelationships(obj) {
           const shouldRecurse = recursions <= maxRecursions;
-          const shouldInclude = self.apos.modules[obj.withType] &&
-             self.apos.modules[obj.withType].options.export !== false;
 
           if (obj.type === 'relationship') {
-            return shouldInclude && obj.withType;
+            return self.canExportDoc(req, obj.withType) && obj.withType;
           } else if (obj.type === 'array' || obj.type === 'object') {
             recursions++;
             return shouldRecurse && obj.schema.flatMap(searchRelationships);

--- a/lib/apiRoutes.js
+++ b/lib/apiRoutes.js
@@ -32,8 +32,7 @@ module.exports = self => {
           const shouldRecurse = recursions <= maxRecursions;
 
           if (obj.type === 'relationship') {
-            // TODO: handle permission here: exclude types that the user cannot access to:
-            return self.canExport(obj.withType) && obj.withType;
+            return self.canExport(req, obj.withType) && obj.withType;
           } else if (obj.type === 'array' || obj.type === 'object') {
             recursions++;
             return shouldRecurse && obj.schema.flatMap(searchRelationships);

--- a/lib/apiRoutes.js
+++ b/lib/apiRoutes.js
@@ -32,9 +32,11 @@ module.exports = self => {
         // option in their module configuration
         function searchRelationships(obj) {
           const shouldRecurse = recursions <= maxRecursions;
+          const shouldInclude = self.apos.modules[obj.withType] &
+             self.apos.modules[obj.withType].options.export !== false;
 
           if (obj.type === 'relationship') {
-            return obj.withType;
+            return shouldInclude && obj.withType;
           } else if (obj.type === 'array' || obj.type === 'object') {
             recursions++;
             return shouldRecurse && obj.schema.flatMap(searchRelationships);

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -14,7 +14,7 @@ module.exports = self => {
       const ids = self.apos.launder.ids(req.body._ids);
       const relatedTypes = self.apos.launder.strings(req.body.relatedTypes);
       const extension = self.apos.launder.string(req.body.extension, 'zip');
-      const expiration = typeof self.options.export === 'object' &&
+      const expiration = self.options.importExport?.export?.expiration &&
         self.apos.launder.integer(self.options.export.expiration);
 
       const format = self.exportFormats[extension];
@@ -149,7 +149,7 @@ module.exports = self => {
         return false;
       }
 
-      if (docModule.options.export === false) {
+      if (docModule.options.importExport?.export === false) {
         return false;
       }
 

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -28,11 +28,16 @@ module.exports = self => {
       if (!relatedTypes.length) {
         const docs = await self.fetchActualDocs(req, allIds, reporting);
 
-        return self.createArchive(req, reporting, this.formatArchiveData(docs), {
-          extension,
-          expiration,
-          format
-        });
+        return self.createArchive(
+          req,
+          reporting,
+          this.formatArchiveData(docs),
+          {
+            extension,
+            expiration,
+            format
+          }
+        );
       }
 
       const draftDocs = await self.getPopulatedDocs(req, manager, allIds, 'draft');
@@ -69,7 +74,8 @@ module.exports = self => {
         })
       );
 
-      return self.createArchive(req,
+      return self.createArchive(
+        req,
         reporting,
         self.formatArchiveData(docs, attachments, attachmentUrls),
         {

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -24,10 +24,11 @@ module.exports = self => {
         throw self.apos.error('invalid');
       }
 
-      const docs = await self.getDocs(req, ids, manager, reporting);
+      const hasRelatedTypes = !!relatedTypes.length;
+      const docs = await self.getDocs(req, ids, hasRelatedTypes, manager, reporting);
       const cleanDocs = self.clean(docs);
 
-      if (!relatedTypes.length) {
+      if (!hasRelatedTypes) {
         return self.createArchive(
           req,
           reporting,
@@ -47,11 +48,10 @@ module.exports = self => {
           relatedTypes
         })
       );
-      const cleanRelatedDocs = self.clean(relatedDocs);
+      cleanDocs.push(...self.clean(relatedDocs));
 
-      const allDocs = _.uniqBy([ ...docs, ...relatedDocs ], doc => doc._id);
-
-      const attachmentsIds = allDocs
+      const attachmentsIds = _
+        .uniqBy([ ...docs, ...relatedDocs ], doc => doc._id)
         .flatMap(doc =>
           self.getRelatedDocsFromSchema(req, {
             doc,
@@ -74,7 +74,7 @@ module.exports = self => {
       return self.createArchive(
         req,
         reporting,
-        self.formatArchiveData([ ...cleanDocs, ...cleanRelatedDocs ], cleanAttachments, attachmentUrls),
+        self.formatArchiveData(cleanDocs, cleanAttachments, attachmentUrls),
         {
           extension,
           expiration,
@@ -86,8 +86,7 @@ module.exports = self => {
     // Get docs via their manager in order to populate them
     // so that we can retrieve their relationships IDs later,
     // and to let the manager handle permissions.
-    // TODO: get draft and live in the same call
-    async getDocs(req, docsIds, manager, reporting) {
+    async getDocs(req, docsIds, includeRelationships, manager, reporting) {
       if (!docsIds.length) {
         return [];
       }
@@ -100,6 +99,7 @@ module.exports = self => {
             $in: draftAndPublishedIds
           }
         })
+        .relationships(includeRelationships)
         // .permission('view-draft') // TODO: add this?
         .toArray();
 
@@ -109,6 +109,7 @@ module.exports = self => {
             $in: draftAndPublishedIds
           }
         })
+        .relationships(includeRelationships)
         // .permission('view-draft') // TODO: add this?
         .toArray();
 
@@ -210,7 +211,8 @@ module.exports = self => {
     },
 
     getRelatedDocsFromSchema(
-      req, {
+      req,
+      {
         doc,
         schema,
         type = 'relationship',

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -18,20 +18,24 @@ module.exports = self => {
         self.apos.launder.integer(self.options.export.expiration);
 
       const format = self.exportFormats[extension];
-
       if (!format) {
         throw self.apos.error('invalid');
       }
 
-      const allIds = self.getAllModesIds(ids);
-
       if (!relatedTypes.length) {
-        const docs = await self.fetchActualDocs(req, allIds, reporting);
+        // No related docs, we simply fetch the docs with the provided ids
+        const docs = await self.getDocs(req, manager, ids);
+        console.log('🚀 ~ file: export.js:28 ~ export ~ docs:', docs);
+        const docsIds = docs.map(doc => doc._id);
+        console.log('🚀 ~ file: export.js:29 ~ export ~ docsIds:', docsIds);
+
+        const rawDocs = await self.getRawDocs(req, docsIds, reporting);
+        console.log('🚀 ~ file: export.js:33 ~ export ~ rawDocs:', rawDocs);
 
         return self.createArchive(
           req,
           reporting,
-          this.formatArchiveData(docs),
+          self.formatArchiveData(rawDocs),
           {
             extension,
             expiration,
@@ -40,35 +44,70 @@ module.exports = self => {
         );
       }
 
-      const draftDocs = await self.getPopulatedDocs(req, manager, allIds, 'draft');
-      const publishedDocs = await self.getPopulatedDocs(req, manager, allIds, 'published');
+      // With related docs, we need the docs relationships populated
+      const docs = await self.getDocs(req, manager, ids, true);
+      const docsIds = docs.map(doc => doc._id);
 
-      // Get related docs id from BOTH the draft and published docs,
-      // since they might have different related documents.
-      const relatedIds = draftDocs
-        .concat(publishedDocs)
-        .flatMap(doc => {
-          return self.getRelatedIdsBySchema(req, {
-            doc,
-            schema: self.apos.modules[doc.type].schema,
-            relatedTypes
-          });
-        });
-
-      const allRelatedIds = self.getAllModesIds(relatedIds);
-
-      const docs = await self.fetchActualDocs(req, [ ...allIds, ...allRelatedIds ], reporting);
-
-      const attachmentsIds = docs.flatMap(doc => {
-        return self.getRelatedIdsBySchema(req, {
+      const related = docs.flatMap(doc =>
+        self.getRelatedBySchema(req, {
           doc,
           schema: self.apos.modules[doc.type].schema,
-          type: 'attachment'
+          relatedTypes
+        })
+      );
+      console.log('related', related);
+
+      // Regroup ids by their type,
+      // eg: `{ topic: [ 'id1', 'id2', 'id3' ], article: [ 'id4', 'id5' ] }`
+      // in order to fetch them via their manager all together:
+      const relatedIdsByType = related.reduce((object, related) => {
+        if (!object[related.type]) {
+          return {
+            ...object,
+            [related.type]: [ related._id ]
+          };
+        }
+        object[related.type].push(related._id);
+        return object;
+      }, {});
+      console.log('relatedIdsByType', relatedIdsByType);
+
+      const getRelatedDocsPromises = Object
+        .entries(relatedIdsByType)
+        .map(([ type, relatedIds ]) => {
+          console.log('type', type);
+          console.log('relatedIds', relatedIds);
+          const manager = self.apos.doc.getManager(type);
+          if (!manager) {
+            return Promise.reject(new Error(`Cannot find the manager for type: ${type}`));
+          }
+          return self.getDocs(req, manager, relatedIds);
         });
-      });
-      const attachments = await self.fetchActualDocs(req, attachmentsIds, reporting, 'attachment');
+      console.log('🚀 ~ file: export.js:84 ~ export ~ getRelatedDocsPromises:', getRelatedDocsPromises);
+
+      const relatedDocsByType = await Promise.all(getRelatedDocsPromises);
+      console.log('🚀 ~ file: export.js:87 ~ export ~ relatedDocs:', relatedDocsByType);
+      const relatedDocsIds = relatedDocsByType.flatMap(
+        relatedDocByType => relatedDocByType.map(relatedDoc => relatedDoc._id)
+      );
+      console.log('🚀 ~ file: export.js:87 ~ export ~ relatedDocsIds:', relatedDocsIds);
+
+      const rawDocs = await self.getRawDocs(req, [ ...docsIds, ...relatedDocsIds ], reporting);
+
+      const attachmentsIds = rawDocs
+        .flatMap(doc =>
+          self.getRelatedBySchema(req, {
+            doc,
+            schema: self.apos.modules[doc.type].schema,
+            type: 'attachment'
+          })
+        )
+        .map(attachment => attachment._id);
+
+      const rawAttachments = await self.getRawDocs(req, attachmentsIds, reporting, 'attachment');
+
       const attachmentUrls = Object.fromEntries(
-        attachments.map((attachment) => {
+        rawAttachments.map((attachment) => {
           const name = `${attachment._id}-${attachment.name}.${attachment.extension}`;
           return [ name, self.apos.attachment.url(attachment, { size: 'original' }) ];
         })
@@ -77,7 +116,7 @@ module.exports = self => {
       return self.createArchive(
         req,
         reporting,
-        self.formatArchiveData(docs, attachments, attachmentUrls),
+        self.formatArchiveData(rawDocs, rawAttachments, attachmentUrls),
         {
           extension,
           expiration,
@@ -86,14 +125,35 @@ module.exports = self => {
       );
     },
 
-    formatArchiveData(docs, attachments = [], urls = {}) {
-      return {
-        json: {
-          'aposDocs.json': JSON.stringify(docs, undefined, 2),
-          'aposAttachments.json': JSON.stringify(attachments, undefined, 2)
-        },
-        attachments: urls
-      };
+    // Get docs via their manager in order to populate them
+    // so that we can retrieve their relationships IDs later.
+    async getDocs(req, manager, docsIds, fullDocs) {
+      const draftAndPublishedIds = self.getAllModesIds(docsIds);
+      const projection = fullDocs
+        ? {}
+        : { _id: 1 };
+
+      const draftDocs = await manager
+        .find(req.clone({ mode: 'draft' }), {
+          _id: {
+            $in: draftAndPublishedIds
+          }
+        })
+        .project(projection)
+        // .permission('view-draft') // TODO: add this?
+        .toArray();
+
+      const publishedDocs = await manager
+        .find(req.clone({ mode: 'published' }), {
+          _id: {
+            $in: draftAndPublishedIds
+          }
+        })
+        .project(projection)
+        // .permission('view-draft') // TODO: add this?
+        .toArray();
+
+      return [ ...draftDocs, ...publishedDocs ];
     },
 
     // Add the published version ID next to each draft ID,
@@ -111,7 +171,7 @@ module.exports = self => {
     // without altering the fields or populating them, as the managers would.
     // It is ok if docs corresponding to published IDs do not exist in the database,
     // as they simply will not be fetched.
-    async fetchActualDocs(req, docsIds, reporting, collection = 'doc') {
+    async getRawDocs(req, docsIds, reporting, collection = 'doc') {
       if (!docsIds.length) {
         return [];
       }
@@ -142,22 +202,22 @@ module.exports = self => {
         });
       }
 
-      return docs.filter(doc => self.canExport(req, doc.type));
+      return docs.filter(doc => self.canExport(doc.type));
     },
 
-    canImport(req, docType) {
-      return self.canImportExport(req, docType, 'import');
+    canImport(docType) {
+      return self.canImportOrExport(docType, 'import');
     },
 
-    canExport(req, docType) {
-      return self.canImportExport(req, docType, 'export');
+    canExport(docType) {
+      return self.canImportOrExport(docType, 'export');
     },
 
     // Filter our docs that have their module with the import or export option set to false
     // and docs that have "admin only" permissions when the user is not an admin.
     // If a user does not have at lease the permission to view the draft, he won't
     // be able to import or export it.
-    canImportExport(req, docType, action) {
+    canImportOrExport(docType, action) {
       const docModule = self.apos.modules[docType];
       if (!docModule) {
         return false;
@@ -167,35 +227,20 @@ module.exports = self => {
         return false;
       }
 
-      const isAdminOnly =
-        docModule.options.viewRole === 'admin' ||
-        docModule.options.editRole === 'admin' ||
-        docModule.options.publishRole === 'admin';
-
-      if (isAdminOnly && req.user.role !== 'admin') {
-        return false;
-      }
-
-      if (!self.apos.permission.can(req, 'view-draft', docType)) {
-        return false;
-      }
-
       return true;
     },
 
-    // Get docs via their manager in order to populate them
-    // so that we can retrieve their relationships IDs later.
-    getPopulatedDocs(req, manager, docsIds, mode) {
-      return manager
-        .find(req.clone({ mode }), {
-          _id: {
-            $in: docsIds
-          }
-        })
-        .toArray();
+    formatArchiveData(docs, attachments = [], urls = {}) {
+      return {
+        json: {
+          'aposDocs.json': JSON.stringify(docs, undefined, 2),
+          'aposAttachments.json': JSON.stringify(attachments, undefined, 2)
+        },
+        attachments: urls
+      };
     },
 
-    getRelatedIdsBySchema(req, {
+    getRelatedBySchema(req, {
       doc, schema, type = 'relationship', relatedTypes, recursion = 0
     }) {
       return schema.flatMap(field => {
@@ -208,12 +253,12 @@ module.exports = self => {
         if (field.withType && relatedTypes && !relatedTypes.includes(field.withType)) {
           return [];
         }
-        if (field.withType && !self.canExport(req, field.withType)) {
+        if (field.withType && !self.canExport(field.withType)) {
           return [];
         }
 
         if (shouldRecurse && field.type === 'array') {
-          return fieldValue.flatMap((subField) => self.getRelatedIdsBySchema(req, {
+          return fieldValue.flatMap((subField) => self.getRelatedBySchema(req, {
             doc: subField,
             schema: field.schema,
             type,
@@ -223,7 +268,7 @@ module.exports = self => {
         }
 
         if (shouldRecurse && field.type === 'object') {
-          return self.getRelatedIdsBySchema(req, {
+          return self.getRelatedBySchema(req, {
             doc: fieldValue,
             schema: field.schema,
             type,
@@ -233,7 +278,7 @@ module.exports = self => {
         }
 
         if (shouldRecurse && field.type === 'area') {
-          return (fieldValue.items || []).flatMap((widget) => self.getRelatedIdsBySchema(req, {
+          return (fieldValue.items || []).flatMap((widget) => self.getRelatedBySchema(req, {
             doc: widget,
             schema: self.apos.modules[`${widget?.type}-widget`]?.schema || [],
             type,
@@ -243,9 +288,16 @@ module.exports = self => {
         }
 
         if (field.type === type) {
+          console.log('fieldValue', fieldValue);
           return Array.isArray(fieldValue)
-            ? fieldValue.map(({ _id }) => _id)
-            : [ fieldValue._id ];
+            ? fieldValue.map(({ _id, type }) => ({
+              _id,
+              type
+            }))
+            : [ {
+              _id: fieldValue._id,
+              type: fieldValue.type
+            } ];
         }
 
         return [];

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -136,39 +136,37 @@ module.exports = self => {
         });
       }
 
-      return self.filterDocs(req, docs);
+      return docs.filter(doc => self.canExportDoc(req, doc.type));
     },
 
     // Filter our docs that have their module with the `export` option set to false
     // and docs that have "admin only" permissions when the user is not an admin.
-    // If a user does not have at lease the permission to view the doc, he won't
+    // If a user does not have at lease the permission to view the draft, he won't
     // be able to download it.
-    filterDocs(req, docs) {
-      return docs.filter(doc => {
-        const module = self.apos.modules[doc.type];
-        if (!module) {
-          return false;
-        }
+    canExportDoc(req, docType) {
+      const docModule = self.apos.modules[docType];
+      if (!docModule) {
+        return false;
+      }
 
-        if (module.options.export === false) {
-          return false;
-        }
+      if (docModule.options.export === false) {
+        return false;
+      }
 
-        const isAdminOnly =
-          module.options.viewRole === 'admin' ||
-          module.options.editRole === 'admin' ||
-          module.options.publishRole === 'admin';
+      const isAdminOnly =
+        docModule.options.viewRole === 'admin' ||
+        docModule.options.editRole === 'admin' ||
+        docModule.options.publishRole === 'admin';
 
-        if (isAdminOnly && req.user.role !== 'admin') {
-          return false;
-        }
+      if (isAdminOnly && req.user.role !== 'admin') {
+        return false;
+      }
 
-        if (!self.apos.permission.can(req, 'view', doc)) {
-          return false;
-        }
+      if (!self.apos.permission.can(req, 'view-draft', docType)) {
+        return false;
+      }
 
-        return true;
-      });
+      return true;
     },
 
     // Get docs via their manager in order to populate them

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -22,15 +22,12 @@ module.exports = self => {
         throw self.apos.error('invalid');
       }
 
-      if (!relatedTypes.length) {
-        // No related docs, we simply fetch the docs with the provided ids
+      const shouldIncludeRelatedDocs = relatedTypes.length;
+      if (!shouldIncludeRelatedDocs) {
         const docs = await self.getDocs(req, manager, ids);
-        console.log('🚀 ~ file: export.js:28 ~ export ~ docs:', docs);
         const docsIds = docs.map(doc => doc._id);
-        console.log('🚀 ~ file: export.js:29 ~ export ~ docsIds:', docsIds);
 
         const rawDocs = await self.getRawDocs(req, docsIds, reporting);
-        console.log('🚀 ~ file: export.js:33 ~ export ~ rawDocs:', rawDocs);
 
         return self.createArchive(
           req,
@@ -44,59 +41,47 @@ module.exports = self => {
         );
       }
 
-      // With related docs, we need the docs relationships populated
-      const docs = await self.getDocs(req, manager, ids, true);
+      const shouldPopulateDocs = true;
+      const docs = await self.getDocs(req, manager, ids, shouldPopulateDocs);
       const docsIds = docs.map(doc => doc._id);
 
-      const related = docs.flatMap(doc =>
-        self.getRelatedBySchema(req, {
+      const relatedDocs = docs.flatMap(doc =>
+        self.getRelatedDocsFromSchema(req, {
           doc,
           schema: self.apos.modules[doc.type].schema,
           relatedTypes
         })
       );
-      console.log('related', related);
 
-      // Regroup ids by their type,
-      // eg: `{ topic: [ 'id1', 'id2', 'id3' ], article: [ 'id4', 'id5' ] }`
+      // Regroup ids by their type, eg: `{ topic: [ 'id1', 'id2', 'id3' ], article: [ 'id4', 'id5' ] }`
       // in order to fetch them via their manager all together:
-      const relatedIdsByType = related.reduce((object, related) => {
-        if (!object[related.type]) {
-          return {
-            ...object,
-            [related.type]: [ related._id ]
-          };
-        }
-        object[related.type].push(related._id);
-        return object;
-      }, {});
-      console.log('relatedIdsByType', relatedIdsByType);
+      const relatedIdsByType = relatedDocs.reduce((memo, relatedDoc) => ({
+        ...memo,
+        [relatedDoc.type]: [ ...(memo[relatedDoc.type] || []), relatedDoc._id ]
+      }), {});
 
-      const getRelatedDocsPromises = Object
+      // Use `self.getDocs` here as well in order to get the related docs
+      // according to the current user permissions, just like we do for the given
+      // docs _ids.
+      const getRelatedDocsByTypePromises = Object
         .entries(relatedIdsByType)
         .map(([ type, relatedIds ]) => {
-          console.log('type', type);
-          console.log('relatedIds', relatedIds);
           const manager = self.apos.doc.getManager(type);
           if (!manager) {
             return Promise.reject(new Error(`Cannot find the manager for type: ${type}`));
           }
           return self.getDocs(req, manager, relatedIds);
         });
-      console.log('🚀 ~ file: export.js:84 ~ export ~ getRelatedDocsPromises:', getRelatedDocsPromises);
 
-      const relatedDocsByType = await Promise.all(getRelatedDocsPromises);
-      console.log('🚀 ~ file: export.js:87 ~ export ~ relatedDocs:', relatedDocsByType);
-      const relatedDocsIds = relatedDocsByType.flatMap(
-        relatedDocByType => relatedDocByType.map(relatedDoc => relatedDoc._id)
-      );
-      console.log('🚀 ~ file: export.js:87 ~ export ~ relatedDocsIds:', relatedDocsIds);
+      const relatedDocsByType = await Promise.all(getRelatedDocsByTypePromises);
+      const relatedDocsByTypeFlatten = relatedDocsByType.flatMap(relatedDocByType => relatedDocByType);
+      const relatedDocsIds = relatedDocsByTypeFlatten.map(relatedDoc => relatedDoc._id);
 
       const rawDocs = await self.getRawDocs(req, [ ...docsIds, ...relatedDocsIds ], reporting);
 
       const attachmentsIds = rawDocs
         .flatMap(doc =>
-          self.getRelatedBySchema(req, {
+          self.getRelatedDocsFromSchema(req, {
             doc,
             schema: self.apos.modules[doc.type].schema,
             type: 'attachment'
@@ -126,7 +111,8 @@ module.exports = self => {
     },
 
     // Get docs via their manager in order to populate them
-    // so that we can retrieve their relationships IDs later.
+    // so that we can retrieve their relationships IDs later,
+    // and to let the manager handle permissions.
     async getDocs(req, manager, docsIds, fullDocs) {
       const draftAndPublishedIds = self.getAllModesIds(docsIds);
       const projection = fullDocs
@@ -240,9 +226,15 @@ module.exports = self => {
       };
     },
 
-    getRelatedBySchema(req, {
-      doc, schema, type = 'relationship', relatedTypes, recursion = 0
-    }) {
+    getRelatedDocsFromSchema(
+      req, {
+        doc,
+        schema,
+        type = 'relationship',
+        relatedTypes,
+        recursion = 0
+      }
+    ) {
       return schema.flatMap(field => {
         const fieldValue = doc[field.name];
         const shouldRecurse = recursion <= MAX_RECURSION;
@@ -258,7 +250,7 @@ module.exports = self => {
         }
 
         if (shouldRecurse && field.type === 'array') {
-          return fieldValue.flatMap((subField) => self.getRelatedBySchema(req, {
+          return fieldValue.flatMap((subField) => self.getRelatedDocsFromSchema(req, {
             doc: subField,
             schema: field.schema,
             type,
@@ -268,7 +260,7 @@ module.exports = self => {
         }
 
         if (shouldRecurse && field.type === 'object') {
-          return self.getRelatedBySchema(req, {
+          return self.getRelatedDocsFromSchema(req, {
             doc: fieldValue,
             schema: field.schema,
             type,
@@ -278,7 +270,7 @@ module.exports = self => {
         }
 
         if (shouldRecurse && field.type === 'area') {
-          return (fieldValue.items || []).flatMap((widget) => self.getRelatedBySchema(req, {
+          return (fieldValue.items || []).flatMap((widget) => self.getRelatedDocsFromSchema(req, {
             doc: widget,
             schema: self.apos.modules[`${widget?.type}-widget`]?.schema || [],
             type,
@@ -288,16 +280,7 @@ module.exports = self => {
         }
 
         if (field.type === type) {
-          console.log('fieldValue', fieldValue);
-          return Array.isArray(fieldValue)
-            ? fieldValue.map(({ _id, type }) => ({
-              _id,
-              type
-            }))
-            : [ {
-              _id: fieldValue._id,
-              type: fieldValue.type
-            } ];
+          return Array.isArray(fieldValue) ? fieldValue : [ fieldValue ];
         }
 
         return [];

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -61,7 +61,7 @@ module.exports = self => {
         )
         .map(attachment => attachment._id);
 
-      const attachments = await self.getAttachments(attachmentsIds);
+      const attachments = await self.getAttachments(req, attachmentsIds);
       const cleanAttachments = self.clean(attachments);
 
       const attachmentUrls = Object.fromEntries(
@@ -128,7 +128,7 @@ module.exports = self => {
         });
       }
 
-      return docs.filter(doc => self.canExport(doc.type));
+      return docs.filter(doc => self.canExport(req, doc.type));
     },
 
     // Add the published version ID next to each draft ID,
@@ -154,13 +154,13 @@ module.exports = self => {
         .map(doc => self.apos.util.clonePermanent(doc));
     },
 
-    getAttachments(ids) {
+    getAttachments(req, ids) {
       if (!ids.length) {
         return [];
       }
 
       // TODO: test with `importExport: { export: false }` option in the attachment module:
-      if (!self.canExport('attachment')) {
+      if (!self.canExport(req, 'attachment')) {
         return [];
       }
 
@@ -173,19 +173,19 @@ module.exports = self => {
         .toArray();
     },
 
-    canImport(docType) {
-      return self.canImportOrExport(docType, 'import');
+    canImport(req, docType) {
+      return self.canImportOrExport(req, docType, 'import');
     },
 
-    canExport(docType) {
-      return self.canImportOrExport(docType, 'export');
+    canExport(req, docType) {
+      return self.canImportOrExport(req, docType, 'export');
     },
 
     // Filter our docs that have their module with the import or export option set to false
     // and docs that have "admin only" permissions when the user is not an admin.
     // If a user does not have at lease the permission to view the draft, he won't
     // be able to import or export it.
-    canImportOrExport(docType, action) {
+    canImportOrExport(req, docType, action) {
       const docModule = self.apos.modules[docType];
 
       if (!docModule) {
@@ -193,6 +193,10 @@ module.exports = self => {
       }
 
       if (docModule.options.importExport?.[action] === false) {
+        return false;
+      }
+
+      if (!self.apos.permission.can(req, 'view', docType)) {
         return false;
       }
 
@@ -230,7 +234,7 @@ module.exports = self => {
         if (field.withType && relatedTypes && !relatedTypes.includes(field.withType)) {
           return [];
         }
-        if (field.withType && !self.canExport(field.withType)) {
+        if (field.withType && !self.canExport(req, field.withType)) {
           return [];
         }
 

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -48,7 +48,6 @@ module.exports = self => {
         })
       );
       const cleanRelatedDocs = self.clean(relatedDocs);
-      console.log(require('util').inspect(relatedDocs, { depth: 9, colors: true, showHidden: false }));
 
       const allDocs = _.uniqBy([ ...docs, ...relatedDocs ], doc => doc._id);
 
@@ -159,6 +158,7 @@ module.exports = self => {
         return [];
       }
 
+      // TODO: test with `importExport: { export: false }` option in the attachment module:
       if (!self.canExport('attachment')) {
         return [];
       }

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -43,7 +43,7 @@ module.exports = self => {
       const relatedIds = draftDocs
         .concat(publishedDocs)
         .flatMap(doc => {
-          return self.getRelatedIdsBySchema({
+          return self.getRelatedIdsBySchema(req, {
             doc,
             schema: self.apos.modules[doc.type].schema,
             relatedTypes
@@ -55,7 +55,7 @@ module.exports = self => {
       const docs = await self.fetchActualDocs(req, [ ...allIds, ...allRelatedIds ], reporting);
 
       const attachmentsIds = docs.flatMap(doc => {
-        return self.getRelatedIdsBySchema({
+        return self.getRelatedIdsBySchema(req, {
           doc,
           schema: self.apos.modules[doc.type].schema,
           type: 'attachment'
@@ -136,20 +136,28 @@ module.exports = self => {
         });
       }
 
-      return docs.filter(doc => self.canExportDoc(req, doc.type));
+      return docs.filter(doc => self.canExport(req, doc.type));
     },
 
-    // Filter our docs that have their module with the `export` option set to false
+    canImport(req, docType) {
+      return self.canImportExport(req, docType, 'import');
+    },
+
+    canExport(req, docType) {
+      return self.canImportExport(req, docType, 'export');
+    },
+
+    // Filter our docs that have their module with the import or export option set to false
     // and docs that have "admin only" permissions when the user is not an admin.
     // If a user does not have at lease the permission to view the draft, he won't
-    // be able to download it.
-    canExportDoc(req, docType) {
+    // be able to import or export it.
+    canImportExport(req, docType, action) {
       const docModule = self.apos.modules[docType];
       if (!docModule) {
         return false;
       }
 
-      if (docModule.options.importExport?.export === false) {
+      if (docModule.options.importExport?.[action] === false) {
         return false;
       }
 
@@ -181,28 +189,25 @@ module.exports = self => {
         .toArray();
     },
 
-    getRelatedIdsBySchema({
+    getRelatedIdsBySchema(req, {
       doc, schema, type = 'relationship', relatedTypes, recursion = 0
     }) {
       return schema.flatMap(field => {
         const fieldValue = doc[field.name];
         const shouldRecurse = recursion <= MAX_RECURSION;
 
-        if (
-          !fieldValue ||
-          (relatedTypes && field.withType && !relatedTypes.includes(field.withType))
-          // TODO: handle 'importExport.export: false' option
-          /* ( */
-          /*   type === 'relationship' && */
-          /*   field.withType && */
-          /*   self.apos.modules[field.withType].options.relatedDocument === false */
-          /* ) */
-        ) {
+        if (!fieldValue) {
+          return [];
+        }
+        if (field.withType && relatedTypes && !relatedTypes.includes(field.withType)) {
+          return [];
+        }
+        if (field.withType && !self.canExport(req, field.withType)) {
           return [];
         }
 
         if (shouldRecurse && field.type === 'array') {
-          return fieldValue.flatMap((subField) => self.getRelatedIdsBySchema({
+          return fieldValue.flatMap((subField) => self.getRelatedIdsBySchema(req, {
             doc: subField,
             schema: field.schema,
             type,
@@ -212,7 +217,7 @@ module.exports = self => {
         }
 
         if (shouldRecurse && field.type === 'object') {
-          return self.getRelatedIdsBySchema({
+          return self.getRelatedIdsBySchema(req, {
             doc: fieldValue,
             schema: field.schema,
             type,
@@ -222,7 +227,7 @@ module.exports = self => {
         }
 
         if (shouldRecurse && field.type === 'area') {
-          return (fieldValue.items || []).flatMap((widget) => self.getRelatedIdsBySchema({
+          return (fieldValue.items || []).flatMap((widget) => self.getRelatedIdsBySchema(req, {
             doc: widget,
             schema: self.apos.modules[`${widget?.type}-widget`]?.schema || [],
             type,

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -100,7 +100,6 @@ module.exports = self => {
           }
         })
         .relationships(includeRelationships)
-        // .permission('view-draft') // TODO: add this?
         .toArray();
 
       const publishedDocs = await manager
@@ -110,7 +109,6 @@ module.exports = self => {
           }
         })
         .relationships(includeRelationships)
-        // .permission('view-draft') // TODO: add this?
         .toArray();
 
       const docs = [ ...draftDocs, ...publishedDocs ];

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -161,7 +161,7 @@ module.exports = self => {
         if (
           !fieldValue ||
           (relatedTypes && field.withType && !relatedTypes.includes(field.withType))
-          // TODO: handle 'exportDoc: false' option
+          // TODO: handle 'importExport.export: false' option
           /* ( */
           /*   type === 'relationship' && */
           /*   field.withType && */

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -136,7 +136,7 @@ module.exports = self => {
         });
       }
 
-      return docs;
+      return docs.filter(doc => self.apos.modules[doc.type] && self.apos.modules[doc.type].options.export !== false);
     },
 
     // Get docs via their manager in order to populate them

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -136,7 +136,39 @@ module.exports = self => {
         });
       }
 
-      return docs.filter(doc => self.apos.modules[doc.type] && self.apos.modules[doc.type].options.export !== false);
+      return self.filterDocs(req, docs);
+    },
+
+    // Filter our docs that have their module with the `export` option set to false
+    // and docs that have "admin only" permissions when the user is not an admin.
+    // If a user does not have at lease the permission to view the doc, he won't
+    // be able to download it.
+    filterDocs(req, docs) {
+      return docs.filter(doc => {
+        const module = self.apos.modules[doc.type];
+        if (!module) {
+          return false;
+        }
+
+        if (module.options.export === false) {
+          return false;
+        }
+
+        const isAdminOnly =
+          module.options.viewRole === 'admin' ||
+          module.options.editRole === 'admin' ||
+          module.options.publishRole === 'admin';
+
+        if (isAdminOnly && req.user.role !== 'admin') {
+          return false;
+        }
+
+        if (!self.apos.permission.can(req, 'view', doc)) {
+          return false;
+        }
+
+        return true;
+      });
     },
 
     // Get docs via their manager in order to populate them

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const { EJSON } = require('bson');
 
 const MAX_RECURSION = 10;
 
@@ -204,9 +205,8 @@ module.exports = self => {
     formatArchiveData(docs, attachments = [], urls = {}) {
       return {
         json: {
-          // TODO: use BSON
-          'aposDocs.json': JSON.stringify(docs, undefined, 2),
-          'aposAttachments.json': JSON.stringify(attachments, undefined, 2)
+          'aposDocs.json': EJSON.stringify(docs, undefined, 2),
+          'aposAttachments.json': EJSON.stringify(attachments, undefined, 2)
         },
         attachments: urls
       };

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -1,3 +1,5 @@
+const _ = require('lodash');
+
 const MAX_RECURSION = 10;
 
 module.exports = self => {
@@ -22,17 +24,14 @@ module.exports = self => {
         throw self.apos.error('invalid');
       }
 
-      const shouldIncludeRelatedDocs = relatedTypes.length;
-      if (!shouldIncludeRelatedDocs) {
-        const docs = await self.getDocs(req, manager, ids);
-        const docsIds = docs.map(doc => doc._id);
+      const docs = await self.getDocs(req, ids, manager, reporting);
+      const cleanDocs = self.clean(docs);
 
-        const rawDocs = await self.getRawDocs(req, docsIds, reporting);
-
+      if (!relatedTypes.length) {
         return self.createArchive(
           req,
           reporting,
-          self.formatArchiveData(rawDocs),
+          self.formatArchiveData(cleanDocs),
           {
             extension,
             expiration,
@@ -41,10 +40,6 @@ module.exports = self => {
         );
       }
 
-      const shouldPopulateDocs = true;
-      const docs = await self.getDocs(req, manager, ids, shouldPopulateDocs);
-      const docsIds = docs.map(doc => doc._id);
-
       const relatedDocs = docs.flatMap(doc =>
         self.getRelatedDocsFromSchema(req, {
           doc,
@@ -52,34 +47,12 @@ module.exports = self => {
           relatedTypes
         })
       );
+      const cleanRelatedDocs = self.clean(relatedDocs);
+      console.log(require('util').inspect(relatedDocs, { depth: 9, colors: true, showHidden: false }));
 
-      // Regroup ids by their type, eg: `{ topic: [ 'id1', 'id2', 'id3' ], article: [ 'id4', 'id5' ] }`
-      // in order to fetch them via their manager all together:
-      const relatedIdsByType = relatedDocs.reduce((memo, relatedDoc) => ({
-        ...memo,
-        [relatedDoc.type]: [ ...(memo[relatedDoc.type] || []), relatedDoc._id ]
-      }), {});
+      const allDocs = _.uniqBy([ ...docs, ...relatedDocs ], doc => doc._id);
 
-      // Use `self.getDocs` here as well in order to get the related docs
-      // according to the current user permissions, just like we do for the given
-      // docs _ids.
-      const getRelatedDocsByTypePromises = Object
-        .entries(relatedIdsByType)
-        .map(([ type, relatedIds ]) => {
-          const manager = self.apos.doc.getManager(type);
-          if (!manager) {
-            return Promise.reject(new Error(`Cannot find the manager for type: ${type}`));
-          }
-          return self.getDocs(req, manager, relatedIds);
-        });
-
-      const relatedDocsByType = await Promise.all(getRelatedDocsByTypePromises);
-      const relatedDocsByTypeFlatten = relatedDocsByType.flatMap(relatedDocByType => relatedDocByType);
-      const relatedDocsIds = relatedDocsByTypeFlatten.map(relatedDoc => relatedDoc._id);
-
-      const rawDocs = await self.getRawDocs(req, [ ...docsIds, ...relatedDocsIds ], reporting);
-
-      const attachmentsIds = rawDocs
+      const attachmentsIds = allDocs
         .flatMap(doc =>
           self.getRelatedDocsFromSchema(req, {
             doc,
@@ -89,10 +62,11 @@ module.exports = self => {
         )
         .map(attachment => attachment._id);
 
-      const rawAttachments = await self.getRawDocs(req, attachmentsIds, reporting, 'attachment');
+      const attachments = await self.getAttachments(attachmentsIds);
+      const cleanAttachments = self.clean(attachments);
 
       const attachmentUrls = Object.fromEntries(
-        rawAttachments.map((attachment) => {
+        attachments.map(attachment => {
           const name = `${attachment._id}-${attachment.name}.${attachment.extension}`;
           return [ name, self.apos.attachment.url(attachment, { size: 'original' }) ];
         })
@@ -101,7 +75,7 @@ module.exports = self => {
       return self.createArchive(
         req,
         reporting,
-        self.formatArchiveData(rawDocs, rawAttachments, attachmentUrls),
+        self.formatArchiveData([ ...cleanDocs, ...cleanRelatedDocs ], cleanAttachments, attachmentUrls),
         {
           extension,
           expiration,
@@ -113,33 +87,48 @@ module.exports = self => {
     // Get docs via their manager in order to populate them
     // so that we can retrieve their relationships IDs later,
     // and to let the manager handle permissions.
-    async getDocs(req, manager, docsIds, fullDocs) {
+    // TODO: get draft and live in the same call
+    async getDocs(req, docsIds, manager, reporting) {
+      if (!docsIds.length) {
+        return [];
+      }
+
       const draftAndPublishedIds = self.getAllModesIds(docsIds);
-      const projection = fullDocs
-        ? {}
-        : { _id: 1 };
 
       const draftDocs = await manager
-        .find(req.clone({ mode: 'draft' }), {
+        .findForEditing(req.clone({ mode: 'draft' }), {
           _id: {
             $in: draftAndPublishedIds
           }
         })
-        .project(projection)
         // .permission('view-draft') // TODO: add this?
         .toArray();
 
       const publishedDocs = await manager
-        .find(req.clone({ mode: 'published' }), {
+        .findForEditing(req.clone({ mode: 'published' }), {
           _id: {
             $in: draftAndPublishedIds
           }
         })
-        .project(projection)
         // .permission('view-draft') // TODO: add this?
         .toArray();
 
-      return [ ...draftDocs, ...publishedDocs ];
+      const docs = [ ...draftDocs, ...publishedDocs ];
+
+      if (reporting) {
+        const docsId = docs.map(doc => doc._id);
+
+        // Verify that each id sent in the body has its corresponding doc fetched
+        docsIds.forEach(id => {
+          const fn = docsId.includes(id)
+            ? 'success'
+            : 'failure';
+
+          reporting[fn]();
+        });
+      }
+
+      return docs.filter(doc => self.canExport(doc.type));
     },
 
     // Add the published version ID next to each draft ID,
@@ -153,42 +142,34 @@ module.exports = self => {
       ]);
     },
 
-    // Fetch the documents exactly as they are in the database,
-    // without altering the fields or populating them, as the managers would.
-    // It is ok if docs corresponding to published IDs do not exist in the database,
-    // as they simply will not be fetched.
-    async getRawDocs(req, docsIds, reporting, collection = 'doc') {
-      if (!docsIds.length) {
+    // Filter our docs which module has the export option disabled
+    // and clone them in order to get clean data for the export (no scalar data).
+    clean(docs) {
+      if (!docs.length) {
         return [];
       }
 
-      const docsIdsUniq = [ ...new Set(docsIds) ];
-      const docs = await self.apos[collection].db
+      return _
+        .uniqBy(docs, doc => doc._id)
+        .map(doc => self.apos.util.clonePermanent(doc));
+    },
+
+    getAttachments(ids) {
+      if (!ids.length) {
+        return [];
+      }
+
+      if (!self.canExport('attachment')) {
+        return [];
+      }
+
+      return self.apos.attachment.db
         .find({
           _id: {
-            $in: docsIdsUniq
+            $in: ids
           }
         })
         .toArray();
-
-      // FIXME: seems like reporting is not working very well,
-      // when calling failure on purpose, we have the progress bar
-      // at 200%... 🤷‍♂️
-      if (reporting) {
-        const { _ids } = req.body;
-        const docsId = docs.map(doc => doc._id);
-
-        // Verify that each id sent in the body has its corresponding doc fetched
-        _ids.forEach(id => {
-          const fn = docsId.includes(id)
-            ? 'success'
-            : 'failure';
-
-          reporting[fn]();
-        });
-      }
-
-      return docs.filter(doc => self.canExport(doc.type));
     },
 
     canImport(docType) {
@@ -205,6 +186,7 @@ module.exports = self => {
     // be able to import or export it.
     canImportOrExport(docType, action) {
       const docModule = self.apos.modules[docType];
+
       if (!docModule) {
         return false;
       }
@@ -219,6 +201,7 @@ module.exports = self => {
     formatArchiveData(docs, attachments = [], urls = {}) {
       return {
         json: {
+          // TODO: use BSON
           'aposDocs.json': JSON.stringify(docs, undefined, 2),
           'aposAttachments.json': JSON.stringify(attachments, undefined, 2)
         },

--- a/modules/@apostrophecms/import-export-doc-type/index.js
+++ b/modules/@apostrophecms/import-export-doc-type/index.js
@@ -14,7 +14,7 @@ module.exports = {
       }
     };
 
-    if (self.options.export === false) {
+    if (self.options.importExport?.export === false) {
       excludedTypes.push({
         type: {
           $ne: self.__meta.name

--- a/modules/@apostrophecms/import-export-page/index.js
+++ b/modules/@apostrophecms/import-export-page/index.js
@@ -2,7 +2,7 @@ module.exports = {
   improve: '@apostrophecms/page',
 
   utilityOperations (self) {
-    if (self.options.import === false) {
+    if (self.options.importExport?.import === false) {
       return {};
     }
 
@@ -25,7 +25,7 @@ module.exports = {
   },
 
   apiRoutes(self) {
-    if (self.options.export === false) {
+    if (self.options.importExport?.export === false) {
       return {};
     }
 

--- a/modules/@apostrophecms/import-export-piece-type/index.js
+++ b/modules/@apostrophecms/import-export-piece-type/index.js
@@ -4,7 +4,7 @@ module.exports = {
   cascades: [ 'batchOperations' ],
 
   utilityOperations (self) {
-    if (self.options.import === false) {
+    if (self.options.importExport?.import === false) {
       return {};
     }
 
@@ -27,7 +27,7 @@ module.exports = {
   },
 
   batchOperations(self) {
-    if (self.options.export === false) {
+    if (self.options.importExport?.export === false) {
       return;
     }
 
@@ -54,7 +54,7 @@ module.exports = {
   },
 
   apiRoutes(self) {
-    if (self.options.export === false) {
+    if (self.options.importExport?.export === false) {
       return {};
     }
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "archiver": "^6.0.0",
+    "lodash": "^4.17.21",
     "tar": "^6.1.15"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "archiver": "^6.0.0",
+    "bson": "^6.0.0",
     "lodash": "^4.17.21",
     "tar": "^6.1.15"
   }


### PR DESCRIPTION
<!-- Please don't delete this template -->

- scope `export` and `import` options into a `importExport` one
- use the manager of the docs and related docs to filter them out if the user does not have sufficient permission
- use `apos.util.clonePermanent` to strip the docs from the scalar properties (except for `_id`)
              --> **We're not fetching docs directly from the mongo anymore**
- refactor code a little bit so it does not become too hard to maintain