### PR TITLE
Check options during import

### DIFF
--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -176,25 +176,17 @@ module.exports = self => {
         .toArray();
     },
 
-    canImport(req, docType) {
-      return self.canImportOrExport(req, docType, 'import');
-    },
-
-    canExport(req, docType) {
-      return self.canImportOrExport(req, docType, 'export');
-    },
-
-    // Filter our docs that have their module with the import or export option set to false
+    // Filter our docs that have their module with the export option set to false
     // and docs that have "admin only" permissions when the user is not an admin.
     // If a user does not have at lease the permission to view the draft, he won't
-    // be able to import or export it.
-    canImportOrExport(req, docType, action) {
+    // be able to export it.
+    canExport(req, docType) {
       const docModule = self.apos.modules[docType];
 
       if (!docModule) {
         return false;
       }
-      if (docModule.options.importExport?.[action] === false) {
+      if (docModule.options.importExport?.export === false) {
         return false;
       }
       if (!self.apos.permission.can(req, 'view', docType)) {

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -273,6 +273,10 @@ module.exports = self => {
         throw new Error(`No manager found for this module: ${doc.type}`);
       }
 
+      if (manager.options.importExport?.import === false) {
+        throw new Error(`Import is disabled for this module: ${doc.type}`);
+      }
+
       if (manager.options.autopublish === true && doc.aposMode === 'published') {
         if (duplicatedIds && duplicatedIds.includes(doc.aposDocId)) {
           return false;

--- a/modules/@apostrophecms/import-export-user/index.js
+++ b/modules/@apostrophecms/import-export-user/index.js
@@ -1,0 +1,9 @@
+module.exports = {
+  improve: '@apostrophecms/user',
+  options: {
+    importExport: {
+      import: false,
+      export: false
+    }
+  }
+};


### PR DESCRIPTION
## Summary

Minor changes:
* Moved import export disabling for users here instead of in core
* Check during import if the type disabled the import, in this case we don't import the doc
* Removes canImport method (we just check the option during the import since the manager already checks the permissions during import)