### PR TITLE
display duplicated docs information in a table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Adds
+
+* Display more information when selecting duplicated docs to override.
+
 ## 1.0.2 (2023-10-13)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Adds
 
-* Display more information when selecting duplicated docs to override.
+* Display more information about duplicated documents.
 
 ## 1.0.2 (2023-10-13)
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,4 +1,5 @@
 {
+  "dayjsTitleDateFormat": "MMM D, YYYY, hh:mm:ss A",
   "export": "Export {{ type }}",
   "exportAttachmentError": "Some attachments could not be added to the {{ format }} file",
   "exportFailed": "Export failed",
@@ -26,5 +27,8 @@
   "imported": "Imported",
   "importing": "Importing {{ type }}...",
   "importWarning": "Importing an Apostrophe export file on an incompatible website may not behave as expected.",
-  "or": "or"
+  "lastEdited": "Last edited",
+  "or": "or",
+  "title": "Title",
+  "type": "Type"
 }

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -223,7 +223,8 @@ module.exports = self => {
             duplicatedDocs.push({
               aposDocId: cloned.aposDocId,
               title: cloned.title,
-              type: cloned.type
+              type: cloned.type,
+              updatedAt: cloned.updatedAt
             });
             duplicatedIds.push(cloned.aposDocId);
           }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "bluebird": "^3.7.2",
     "bson": "^6.0.0",
+    "dayjs": "^1.9.8",
     "lodash": "^4.17.21",
     "tar-stream": "^3.1.6"
   }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

- display duplicated docs type and the date they were last edited in a table.
- use AposButton to toggle all docs and change its style to make it look like exactly the same as other checkboxes

## What are the specific steps to test this change?

| none selected | few selected | all selected | long text |
|--------|--------|--------|------|
| <img width="450" alt="image" src="https://github.com/apostrophecms/import-export/assets/8301962/091edcba-f1d4-41fe-85cc-250c6c912f1b"> | <img width="451" alt="image" src="https://github.com/apostrophecms/import-export/assets/8301962/5852c82c-5028-41d3-b2f0-802b9d62ff32"> | <img width="459" alt="image" src="https://github.com/apostrophecms/import-export/assets/8301962/5b174b9e-cfc9-46a8-87dd-bae9308bb3d7"> | <img width="615" alt="image" src="https://github.com/apostrophecms/import-export/assets/8301962/41808bf9-495f-4863-8c5c-39181afc357e"> |

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
