### PR TITLE
Remove 'Duplicate Detected' notification

### DIFF
--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -76,15 +76,6 @@ module.exports = self => {
         notificationId
       };
 
-      await self.apos.notify(req, 'aposImportExport:importDuplicateDetected', {
-        icon: 'database-import-icon',
-        type: 'warning',
-        event: {
-          name: 'import-duplicates',
-          data: results
-        }
-      });
-
       self.cleanFile(filePath);
 
       return results;


### PR DESCRIPTION
this is redundant, the editor must face the duplicate resolution modal anyway
