### PR TITLE
when exporting, using location.assign avoids tab/window flash

### DIFF
--- a/ui/apos/apps/index.js
+++ b/ui/apos/apps/index.js
@@ -13,7 +13,7 @@ export default () => {
 
   function openUrl(event) {
     if (event.url) {
-      window.open(event.url, '_blank');
+      window.location.assign(event.url);
     }
   }
 


### PR DESCRIPTION
window.open(event.url) made the browser go through some step of opening a new tab/window/session when downloading the exported file. `assign.location` makes the UI behave seamlessly

https://stackoverflow.com/a/7208039

window flash

https://github.com/apostrophecms/import-export/assets/1889830/913cc902-6a77-44a3-9a35-021bc434f27b

