### PR TITLE
fix progress bar going over 100%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Display more information about duplicated documents.
 
+### Fixes
+
+* Fix progress bar going over `100%` when importing docs that are archived after being exported.
+
 ## 1.0.2 (2023-10-13)
 
 ### Fixes

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -269,15 +269,18 @@ module.exports = self => {
         throw new Error(`Import is disabled for this module: ${doc.type}`);
       }
 
-      if (manager.options.autopublish === true && doc.aposMode === 'published') {
-        if (duplicatedIds && duplicatedIds.includes(doc.aposDocId)) {
-          return false;
-        }
+      if (doc.aposMode === 'published') {
         if (failedIds && failedIds.includes(doc.aposDocId)) {
           throw new Error('Inserting document failed');
         }
 
-        return true;
+        if (duplicatedIds && duplicatedIds.includes(doc.aposDocId)) {
+          return false;
+        }
+
+        if (manager.options.autopublish === true) {
+          return true;
+        }
       }
 
       if (isPage) {


### PR DESCRIPTION
Fix progress bar going over `100%` when importing docs that are archived after being exported.