### PR TITLE
Pro-5005-exported-file-name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Adds
 
 * Display more information about duplicated documents.
+* Export file name more meaningful, containing project name, module name and current date and time.
 
 ### Fixes
 

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -3,6 +3,7 @@ const path = require('path');
 const util = require('util');
 const { uniqBy } = require('lodash');
 const { EJSON } = require('bson');
+const dayjs = require('dayjs');
 
 const MAX_RECURSION = 10;
 
@@ -280,7 +281,8 @@ module.exports = self => {
     },
 
     async writeExportFile(req, reporting, data, { format, expiration }) {
-      const filename = `${self.apos.util.generateId()}-export${format.extension}`;
+      const date = dayjs().format('YYYYMMDDHHmmss');
+      const filename = `${self.apos.shortName}-${req.body.type.toLowerCase()}-export-${date}${format.extension}`;
       const filepath = path.join(self.apos.attachment.uploadfs.getTempPath(), filename);
 
       try {

--- a/ui/apos/apps/index.js
+++ b/ui/apos/apps/index.js
@@ -13,7 +13,7 @@ export default () => {
 
   function openUrl(event) {
     if (event.url) {
-      window.location.assign(event.url);
+      window.open(event.url, '_blank');
     }
   }
 


### PR DESCRIPTION
https://linear.app/apostrophecms/issue/PRO-5005/importexport-exported-file-name-unhelpful

# Import/export: exported file name unhelpful

When you export a gzip from the import/export module, the resulting filename is unhelpful, mostly a random uuid.

This should follow a pattern like

```
  <short-name>-<document-type>-export-<timestamp>
````

It  would become
  `a3-demo-articles-export-20231018T122551Z`

## Acceptance Criteria

Given I'm a user who exports [Articles] from my [a3-demo] site, and the download is successful, the file should be named a3-demo-articles-export-timestamp.

## Cypress tests

Run ok: https://github.com/apostrophecms/testbed/actions/runs/6745532163

<img width="1164" alt="image" src="https://github.com/apostrophecms/import-export/assets/11479686/4915eccf-f6a5-42ed-9a24-c5678746cd25">
