### PR TITLE
add custom class to hide duplicated docs notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Changes
+
+* Hide "Duplicates Detected." notification.
+
 ## 1.1.0 (2023-11-03)
 
 ### Adds

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -76,9 +76,9 @@ module.exports = self => {
         notificationId
       };
 
-      await self.apos.notify(req, 'aposImportExport:importDuplicateDetected', {
-        icon: 'database-import-icon',
-        type: 'warning',
+      // we only care about the event here,
+      // to display the duplicated docs modal
+      await self.apos.notify(req, ' ', {
         event: {
           name: 'import-duplicates',
           data: results

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -83,7 +83,7 @@ module.exports = self => {
           name: 'import-duplicates',
           data: results
         },
-        class: 'apos-notification--hidden'
+        classes: [ 'apos-notification--hidden' ]
       });
 
       self.cleanFile(filePath);

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -79,6 +79,7 @@ module.exports = self => {
       // we only care about the event here,
       // to display the duplicated docs modal
       await self.apos.notify(req, ' ', {
+        type: 'warning',
         event: {
           name: 'import-duplicates',
           data: results

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -82,7 +82,8 @@ module.exports = self => {
         event: {
           name: 'import-duplicates',
           data: results
-        }
+        },
+        class: 'apos-notification--hidden'
       });
 
       self.cleanFile(filePath);


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Hide the "Duplicates detected" warning.

Relies on https://github.com/apostrophecms/apostrophe/pull/4334
