### PR TITLE
feat(PRO-5623): fix issue in import-export when publishing then unpublishing

### DIFF
--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -388,8 +388,6 @@ module.exports = self => {
         doc.lastPublishedAt = existing.lastPublishedAt;
       }
 
-      console.log('Plop', method, doc)
-
       if (isPage) {
         return method === 'update'
           ? manager[method](req, doc, { setModified: false })

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -374,6 +374,22 @@ module.exports = self => {
         }
       }
 
+      if (method === 'update' && doc.aposMode === 'draft') {
+        console.log('doc._id >   ', doc._id)
+        const existing = await self.apos.doc.db.findOne({ _id: doc._id }, {
+          lastPublishedAt: 1
+        });
+        // const currentDoc = await manager
+        //   .find(req, { _id: doc._id })
+        //   .project({ lastPublishedAt: 1 })
+        //   .toObject();
+        console.log(existing);
+
+        doc.lastPublishedAt = existing.lastPublishedAt;
+      }
+
+      console.log('Plop', method, doc)
+
       if (isPage) {
         return method === 'update'
           ? manager[method](req, doc, { setModified: false })

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -375,10 +375,12 @@ module.exports = self => {
       }
 
       if (method === 'update' && doc.aposMode === 'draft') {
-        const existing = await self.apos.doc.db.findOne({ _id: doc._id }, {
+        const existingDoc = await self.apos.doc.db.findOne({ _id: doc._id }, {
           lastPublishedAt: 1
         });
-        doc.lastPublishedAt = existing.lastPublishedAt;
+        if (existingDoc) {
+          doc.lastPublishedAt = existingDoc.lastPublishedAt;
+        }
       }
 
       if (isPage) {

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -375,16 +375,9 @@ module.exports = self => {
       }
 
       if (method === 'update' && doc.aposMode === 'draft') {
-        console.log('doc._id >   ', doc._id)
         const existing = await self.apos.doc.db.findOne({ _id: doc._id }, {
           lastPublishedAt: 1
         });
-        // const currentDoc = await manager
-        //   .find(req, { _id: doc._id })
-        //   .project({ lastPublishedAt: 1 })
-        //   .toObject();
-        console.log(existing);
-
         doc.lastPublishedAt = existing.lastPublishedAt;
       }
 

--- a/test/index.js
+++ b/test/index.js
@@ -220,108 +220,6 @@ describe('@apostrophecms/import-export', function () {
     await cleanFile(exportPath);
   });
 
-  it.only('should preserve lastPublishedAt property on import for existing drafts', async function() {
-    console.log('[TEST] should preserve lastPublishedAt property on import for existing drafts');
-
-    // Get the page2 that was meant for testing
-    const req = apos.task.getReq();
-    const page2 = await apos.page.find(req, { title: 'page2' }).toObject();
-    
-    // PUBLISH IT
-    const publishedResult = await apos.page.publish(req, page2);
-    // THEN UNPUBLISH IT
-    const draftPage = await apos.page.unpublish(req, page2);
-
-    // THEN EXPORT IT (as draft)
-    req.body = {
-      _ids: [ draftPage._id ],
-      extension: 'gzip',
-      type: draftPage.type
-    };
-
-    const { url } = await importExportManager.export(req, apos.page);
-    const fileName = path.basename(url);
-
-    pageTgzPath = path.join(exportsPath, fileName);
-    const exportPath = await gzip.input(pageTgzPath);
-
-    const { docs } = await getExtractedFiles(exportPath);
-    const exportedDraftPage = docs.find(doc => doc._id === draftPage._id);
-
-    console.log('docs (exported) >>>', docs);
-
-    // @TODO Delete:
-    // Test exported doc 
-    const exportedDoc = await apos.doc.db
-    .find({ type: /default-page|article|topic|@apostrophecms\/image/, title: 'page2' })
-    .toArray();
-    // Last published at est bien à "null" et c'est bien un draft
-
-    // Seems it correctly exported
-    // Now we PUBLISH it
-    const result = await apos.page.publish(req, draftPage);
-    console.log({ result });
-
-    const updatedPage2 = await apos.doc.db
-      .find({ title: 'page2', aposMode: 'published' })
-      .toArray();
-    console.log(updatedPage2);
-
-    // Rename tar file for import issue
-    const currentPath = pageTgzPath;
-    const newPath = currentPath.replace('.tar.gz', '-import.tar.gz');
-    try {
-      await fs.rename(currentPath, newPath);
-      console.log(`Fichier renommé de ${currentPath} à ${newPath}`);
-    } catch (error) {
-      console.error('Erreur lors du renommage du fichier :', error);
-    }
-
-    console.log('Then import it');
-
-    // IMPORT IT
-    req.body = {};
-    req.files = {
-      file: {
-        path: newPath,
-        type: mimeType
-      }
-    };
-
-    const {
-      duplicatedDocs,
-      importedAttachments,
-      exportPathId,
-      jobId,
-      notificationId
-    } = await importExportManager.import(req);
-
-    req.body = {
-      docIds: duplicatedDocs.map(doc => doc.aposDocId),
-      importedAttachments,
-      exportPathId,
-      jobId,
-      notificationId
-    }
-
-    await importExportManager.overrideDuplicates(req);
-
-    const NewUpdatedPage2 = await apos.doc.db
-    .find({ title: 'page2' })
-    .toArray();
-    console.log('NewUpdatedPage2 >>>', NewUpdatedPage2);
-
-    // Check that the imported docs are not `null` 
-
-    assert.deepEqual(NewUpdatedPage2.some((doc) => {
-      console.log('doc.lastPublishedAt > ', doc.lastPublishedAt)
-      return doc.lastPublishedAt === null;
-    }), false, 'expected none of the imported docs to have a `lastPublishedAt` value of `null`');
-
-    // @TODO: Cleanup
-    // ...
-  });
-
   it('should import pieces with related documents from a compressed file', async function() {
     const req = apos.task.getReq();
 
@@ -681,6 +579,118 @@ describe('@apostrophecms/import-export', function () {
     assert.deepEqual(actual, expected);
 
     await cleanFile(pageTgzPath.replace(gzip.allowedExtension, ''));
+  });
+
+  it('should preserve lastPublishedAt property on import for existing drafts', async function() {
+    const req = apos.task.getReq();
+    const manager = apos.doc.getManager('default-page');
+    const pageInstance = manager.newInstance();
+
+    await apos.page.insert(req, '_home', 'lastChild', {
+      ...pageInstance,
+      title: 'page2',
+      type: 'default-page',
+      _articles: [],
+      main: {
+        _id: 'areaId',
+        items: [],
+        metaType: 'area'
+      }
+    });
+    const page2 = await apos.page.find(req, { title: 'page2' }).toObject();
+
+    const publishedResult = await apos.page.publish(req, page2);
+    const draftPage = await apos.page.unpublish(req, page2);
+
+    req.body = {
+      _ids: [ draftPage._id ],
+      extension: 'gzip',
+      type: draftPage.type
+    };
+
+    const { url } = await importExportManager.export(req, apos.page);
+    const fileName = path.basename(url);
+
+    pageTgzPath = path.join(exportsPath, fileName);
+    const exportPath = await gzip.input(pageTgzPath);
+
+    const { docs } = await getExtractedFiles(exportPath);
+    const exportedDraftPage = docs.find(doc => doc._id === draftPage._id);
+
+    // @TODO Delete:
+    // Test exported doc
+    const exportedDoc = await apos.doc.db
+      .find({
+        type: /default-page|article|topic|@apostrophecms\/image/,
+        title: 'page2'
+      })
+      .toArray();
+    // Last published at est bien à "null" et c'est bien un draft
+
+    // Seems it correctly exported
+    // Now we PUBLISH it
+    const result = await apos.page.publish(req, draftPage);
+
+    const updatedPage2 = await apos.doc.db
+      .find({
+        title: 'page2',
+        aposMode: 'published'
+      })
+      .toArray();
+
+    // Rename tar file for import issue
+    const currentPath = pageTgzPath;
+    const newPath = currentPath.replace('.tar.gz', '-import.tar.gz');
+    try {
+      await fs.rename(currentPath, newPath);
+      console.log(`Fichier renommé de ${currentPath} à ${newPath}`);
+    } catch (error) {
+      console.error('Erreur lors du renommage du fichier :', error);
+    }
+
+    console.log('Then import it');
+
+    // IMPORT IT
+    req.body = {};
+    req.files = {
+      file: {
+        path: newPath,
+        type: mimeType
+      }
+    };
+
+    const {
+      duplicatedDocs,
+      importedAttachments,
+      exportPathId,
+      jobId,
+      notificationId
+    } = await importExportManager.import(req);
+
+    req.body = {
+      docIds: duplicatedDocs.map(doc => doc.aposDocId),
+      importedAttachments,
+      exportPathId,
+      jobId,
+      notificationId
+    };
+
+    await importExportManager.overrideDuplicates(req);
+
+    const NewUpdatedPage2 = await apos.doc.db
+      .find({ title: 'page2' })
+      .toArray();
+    console.log('NewUpdatedPage2 >>>', NewUpdatedPage2);
+
+    // Check that the imported docs are not `null`
+
+    assert.deepEqual(NewUpdatedPage2.some((doc) => {
+      console.log('doc.lastPublishedAt > ', doc.lastPublishedAt);
+      return doc.lastPublishedAt === null;
+    }), false, 'expected none of the imported docs to have a `lastPublishedAt` value of `null`');
+
+    // @TODO: Cleanup
+    // ...
   });
 
   describe('#getFirstDifferentLocale', function() {
@@ -1512,19 +1522,7 @@ async function insertPieces(apos) {
         }
       ],
       metaType: 'area'
-    },
-  });
-
-  await apos.page.insert(req, '_home', 'lastChild', {
-    ...pageInstance,
-    title: 'page2',
-    type: 'default-page',
-    _articles: [],
-    main: {
-      _id: 'areaId',
-      items: [],
-      metaType: 'area'
-    },
+    }
   });
 }
 


### PR DESCRIPTION
## Description
This PR addresses a bug in the import-export functionality in ApostropheCMS. When a piece or a page is created, published, then unpublished, and subsequently exported and re-imported, the manager modal incorrectly shows no published version. This occurs because the `lastPublishedAt` property of the draft document is set to `null` upon import, misleading the representation of the document's published state.

## Issue
[PRO-5623: Bug in import-export caused by Advanced Permissions](https://linear.app/apostrophecms/issue/PRO-5623/bug-in-import-export-caused-by-advanced-permissions)

## Solution
- The import process is updated to no longer import the `lastPublishedAt` property. 
- For existing draft documents, we retain the current `lastPublishedAt` value instead of importing it.
- If the draft document does not exist, implying there's no published document, `lastPublishedAt` is set to `null`.
- This approach ensures that the draft's publication status is accurately reflected in the manager modal, adhering to Apostrophe's content management guarantees.

## Testing Steps
1. Create, publish, and then unpublish a piece/page.
2. Export the content.
3. Re-publish and import the previously exported content.
4. Verify in the manager modal that the piece/page appears with the correct published status.

Also, the mocha tests should run properly, obviously.
