### PR TITLE
clones req with the right mode before to insert or update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Changes
 
 * Documentation update only. No code changes.
+
+### Fixes
+
+* Fixes imported data with the wrong mode because `req.mode` was always `published`, even for draft documents.
+
 ## 1.4.0 (2024-03-12)
 
 ### Changes

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -383,13 +383,15 @@ module.exports = self => {
         }
       }
 
+      const _req = req.clone({ mode: doc.aposMode });
+
       if (isPage) {
         return method === 'update'
-          ? manager[method](req, doc, { setModified: false })
-          : manager[method](req, '_home', 'lastChild', doc, { setModified: false }); // TODO: manage target?
+          ? manager[method](_req, doc, { setModified: false })
+          : manager[method](_req, '_home', 'lastChild', doc, { setModified: false }); // TODO: manage target?
       }
 
-      return manager[method](req, doc, { setModified: false });
+      return manager[method](_req, doc, { setModified: false });
     },
 
     async insertOrUpdateAttachment(req, {

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -388,7 +388,7 @@ module.exports = self => {
       if (isPage) {
         return method === 'update'
           ? manager[method](_req, doc, { setModified: false })
-          : manager[method](_req, '_home', 'lastChild', doc, { setModified: false }); // TODO: manage target?
+          : manager[method](_req, '_home', 'lastChild', doc, { setModified: false });
       }
 
       return manager[method](_req, doc, { setModified: false });


### PR DESCRIPTION
[PRO-5624](https://linear.app/apostrophecms/issue/PRO-5624/bug-related-to-importing-a-piece-or-a-page)

## Summary

When importing draft documents they had corrupted data because `req.mode` needs to match `doc.aposMode` otherwise  the core `beforeInsert` does weird stuff reassigning only `aposMode` of the document based on `req.mode`.


## What are the specific steps to test this change?

When importing you never end up with data like that:
```
    _id: 'cltx1oo3m000lqvmd6yy1cwnw:en:draft',
    title: 'test',
    aposLocale: 'en:draft',
    aposMode: 'published',
```

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated