### PR TITLE
add the key column feature to update existing documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Thanks to this, this module reaches parity with the deprecated [`@apostrophecms/
 
 ### Fixes
 
-* We can now import pieces or pages with an import file that contains just the required fields. Before that, CSV import files had to contain all the document attributes, which was only the case when importing a file previously exported using this module.
+* We can now import pieces or pages with an import file that contains just the required fields.
 
 ## 2.0.0 (2024-05-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## UNRELEASED
+
+### Adds
+
+* Add the possibility to set a **key column** in your import CSV file in order to update existing pieces and pages.  
+Thanks to this, this module reaches parity with the deprecated [`@apostrophecms/piece-type-importer`](https://github.com/apostrophecms/piece-type-importer) module.
+
+### Fixes
+
+* We can now import pieces or pages with an import file that contains just the required fields. Before that, CSV import files had to contain all the document attributes, which was only the case when importing a file previously exported using this module.
+
 ## 2.0.0 (2024-05-15)
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -148,6 +148,34 @@ If multiple locales are set up, the user will be prompted to choose between canc
 
 ![Screenshot highlighting the confirm modal letting the user choose between aborting on continuing the import when the docs locale is different from the site one.](https://static.apostrophecms.com/apostrophecms/import-export/images/different-locale-modal.png)
 
+## Updating existing pieces using CSV format
+
+You can also update existing pieces via this module.
+
+To do that, you will need one (and only one) **key column** in your file. This column's name **must be exactly the name of the existing field** that uniquely identifies each row as an update of a specific existing piece, **followed by `:key`**.
+
+For instance, if you need to change the usernames of users in bulk, you might prepare a CSV file like this:
+
+```
+username:key,username
+bobsmith,bob.smith
+janedoe,jane.doe
+```
+
+The key column is the *old value*. You may optionally also present a *new value* for that same column in a separate column without `:key`. You may also include other columns, as you see fit. The important thing is that you must have one and only one `:key` column in order to carry out updates.
+
+Please note that both the draft and the published versions will be updated, even if one of them does not match the key column value.
+
+## Mixing inserts and updates
+
+If a row has no value for your `:key` column, it is treated as an insert, rather than an update.
+
+## Importing rich text (HTML) rather than plaintext
+
+By default, if you create a column in your CSV file for a field of type `area`, it will be imported as plaintext. Any special characters like `<` and `>` will be escaped so the user can see them. HTML is not supported.
+
+To import areas as rich text HTML markup, add the `importAsRichText: true` option to the `area` field in your schema.
+
 ## How to add a new format?
 
 ### Create a file for your format:

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -32,5 +32,8 @@
   "lastEdited": "Last edited",
   "or": "or",
   "title": "Title",
-  "type": "Type"
+  "type": "Type",
+  "typeColumnMissing": "\"type\" is missing for the document with \"{{ updateKey }}\" as update key.",
+  "typeUnknown": "Unknown \"{{ type }}\" type.",
+  "typeUnknownWithUpdateKey": "Unknown \"{{ type }}\" type for the document with \"{{ updateKey }}\" as update key."
 }

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -323,7 +323,6 @@ module.exports = self => {
       updateField
     }) {
       const isPage = self.apos.page.isPage(doc);
-      console.log('🚀 ~ isPage:', isPage);
       const manager = isPage
         ? self.apos.page
         : self.apos.modules[doc.type];
@@ -332,69 +331,60 @@ module.exports = self => {
       if (!manager) {
         throw new Error(`No manager found for this module: ${doc.type}`);
       }
-
-      // Import can be disable at the page-type level
       if (!self.canImport(req, doc.type)) {
         throw new Error(`Import is disabled for this module: ${doc.type}`);
       }
 
-      // FIXME: options.importAsRichText
-      manager.schema.forEach(field => {
-        if (field.options && field.options.importAsRichText) {
-          doc[field.name] = self.apos.area.fromRichText(doc[field.name]);
-        }
-      });
+      prepare();
 
       if (!doc[updateKey]) {
-        await insert(doc, 'draft');
-        await insert(doc, 'published');
+        return insert();
       }
 
-      for (const mode of [ 'draft', 'published' ]) {
-        const _req = req.clone({ mode });
-        const existingDoc = await manager.findForEditing(_req, {
-          aposMode: mode,
-          [updateField]: doc[updateKey]
-        }).toObject();
-        console.log('🚀 ~ mode:', mode);
-        console.log('🚀 ~ existingDoc:', existingDoc);
+      const _req = req.clone({ mode: 'draft' });
+      const existingDoc = await manager.findForEditing(_req, {
+        aposMode: 'draft',
+        [updateField]: doc[updateKey]
+      }).toObject();
+      console.log('🚀 ~ existingDoc:', existingDoc);
 
-        if (!existingDoc) {
-          await insert(doc, mode);
-        } else {
-          await update(doc, existingDoc, mode);
-        }
+      if (!existingDoc) {
+        return insert();
       }
 
-      async function insert(doc, mode) {
-        const _req = req.clone({ mode });
+      return update();
 
-        const docToImport = {};
-        await manager.convert(req, doc, docToImport);
-
-        if (isPage) {
-          await manager.insert(_req, '_home', 'lastChild', docToImport, { setModified: false });
-        }
-
-        await manager.insert(_req, docToImport, { setModified: false });
-      }
-
-      async function update(doc, existingDoc, mode) {
-        console.log('🚀 ~ update ~ doc:', doc);
-        console.log('🚀 ~ update ~ existingDoc:', existingDoc);
-        const _req = req.clone({ mode });
-
-        doc.lastPublishedAt = existingDoc.lastPublishedAt;
-
+      function prepare() {
         if (!doc[updateField]) {
           doc[updateField] = doc[updateKey];
         }
 
-        delete doc[updateKey];
+        manager.schema.forEach(field => {
+          if (field.options && field.options.importAsRichText) {
+            doc[field.name] = self.apos.area.fromRichText(doc[field.name]);
+          }
+        });
+      }
 
-        console.log('🚀 ~ update ~ doc:', doc);
+      async function insert() {
+        const _req = req.clone({ mode: 'published' });
 
-        await manager.convert(req, doc, existingDoc);
+        const docToImport = {};
+        await manager.convert(_req, doc, docToImport);
+
+        if (isPage) {
+          return manager.insert(_req, '_home', 'lastChild', docToImport, { setModified: false });
+        }
+
+        return manager.insert(_req, docToImport, { setModified: false });
+      }
+
+      async function update() {
+        const _req = req.clone({ mode: 'published' });
+
+        doc.lastPublishedAt = existingDoc.lastPublishedAt;
+
+        await manager.convert(_req, doc, existingDoc);
         return manager.update(_req, existingDoc, { setModified: false });
       }
     },

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -341,18 +341,49 @@ module.exports = self => {
         return insert();
       }
 
-      const _req = req.clone({ mode: 'draft' });
-      const existingDoc = await manager.findForEditing(_req, {
-        aposMode: 'draft',
-        [updateField]: doc[updateKey]
-      }).toObject();
-      console.log('🚀 ~ existingDoc:', existingDoc);
+      const existingDraft = await manager.findForEditing(
+        req.clone({ mode: 'draft' }),
+        {
+          aposMode: 'draft',
+          [updateField]: doc[updateKey]
+        }).toObject();
 
-      if (!existingDoc) {
+      const existingPublished = await manager.findForEditing(
+        req.clone({ mode: 'published' }),
+        {
+          aposMode: 'published',
+          [updateField]: doc[updateKey]
+        }).toObject();
+
+      console.log('🚀 ~ existingDraft:', existingDraft);
+      console.log('🚀 ~ existingPublished:', existingPublished);
+
+      if (!existingDraft && !existingPublished) {
         return insert();
       }
 
       return update();
+
+      // return Promise.all([
+      //   update('draft'),
+      //   update('published')
+      // ]);
+
+      // if (existingDraft && existingPublished) {
+      //   return Promise.all([
+      //     update('draft'),
+      //     update('published')
+      //   ]);
+      // }
+
+      // if (existingDraft) {
+      //   return Promise.all([
+      //     update('draft'),
+      //     update('published')
+      //   ]);
+      // }
+
+      // return update();
 
       function prepare() {
         if (!doc[updateField]) {
@@ -380,12 +411,40 @@ module.exports = self => {
       }
 
       async function update() {
-        const _req = req.clone({ mode: 'published' });
+        // FIXME: use procedural code instead
+        // A complicated way to get the corresponding draft or published document.
+        // At this point, we know that at least one of them exists.
+        const existingDocs = Object
+          .entries({
+            draft: existingDraft,
+            published: existingPublished
+          })
+          .map(async ([ mode, existingDoc ]) => {
+            if (!existingDoc) {
+              existingDoc = await manager
+                .findForEditing(
+                  req.clone({ mode }),
+                  {
+                    aposMode: mode,
+                    aposDocId: mode === 'draft'
+                      ? existingPublished.aposDocId
+                      : existingDraft.aposDocId
+                  })
+                .toObject();
+            }
+            return existingDoc;
+          });
 
-        doc.lastPublishedAt = existingDoc.lastPublishedAt;
+        console.dir(existingDocs, { depth: 9 });
 
-        await manager.convert(_req, doc, existingDoc);
-        return manager.update(_req, existingDoc, { setModified: false });
+        for (const existingDoc of existingDocs) {
+          const _req = req.clone({ mode: existingDoc.aposMode });
+
+          doc.lastPublishedAt = existingDoc.lastPublishedAt;
+
+          await manager.convert(_req, doc, existingDoc);
+          await manager.update(_req, existingDoc, { setModified: false });
+        }
       }
     },
 

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -392,10 +392,15 @@ module.exports = self => {
         // in both draft and published versions:
         const _req = req.clone({ mode: 'published' });
 
+        const type = doc.type;
         const docToInsert = {};
-        await manager.convert(_req, doc, docToInsert);
+        await manager.convert(_req, doc, docToInsert, { presentFieldsOnly: true });
 
         if (self.isPage(manager)) {
+          // `convert` sets the type to `@apostrophecms/home-page`,
+          // let's set it back to the original type:
+          docToInsert.type = type;
+
           return self.apos.page.insert(_req, '_home', 'lastChild', docToInsert, { setModified: false });
         }
 
@@ -427,7 +432,7 @@ module.exports = self => {
         for (const docToUpdate of docsToUpdate) {
           const _req = req.clone({ mode: docToUpdate.aposMode });
 
-          await manager.convert(_req, doc, docToUpdate);
+          await manager.convert(_req, doc, docToUpdate, { presentFieldsOnly: true });
           await manager.update(_req, docToUpdate);
         }
 
@@ -533,10 +538,16 @@ module.exports = self => {
       async function insert() {
         const _req = req.clone({ mode: doc.aposMode });
 
+        const type = doc.type;
         const docToInsert = doc;
+
         await manager.convert(_req, doc, docToInsert, { presentFieldsOnly: true });
 
         if (self.isPage(manager)) {
+          // `convert` sets the type to `@apostrophecms/home-page`,
+          // let's set it back to the original type:
+          docToInsert.type = type;
+
           return self.apos.page.insert(_req, '_home', 'lastChild', docToInsert, { setModified: false });
         }
 

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -341,49 +341,28 @@ module.exports = self => {
         return insert();
       }
 
-      const existingDraft = await manager.findForEditing(
+      const matchingDraft = await manager.findForEditing(
         req.clone({ mode: 'draft' }),
         {
           aposMode: 'draft',
           [updateField]: doc[updateKey]
         }).toObject();
 
-      const existingPublished = await manager.findForEditing(
+      const matchingPublished = await manager.findForEditing(
         req.clone({ mode: 'published' }),
         {
           aposMode: 'published',
           [updateField]: doc[updateKey]
         }).toObject();
 
-      console.log('🚀 ~ existingDraft:', existingDraft);
-      console.log('🚀 ~ existingPublished:', existingPublished);
+      console.log('🚀 ~ matchingDraft:', matchingDraft);
+      console.log('🚀 ~ matchingPublished:', matchingPublished);
 
-      if (!existingDraft && !existingPublished) {
+      if (!matchingDraft && !matchingPublished) {
         return insert();
       }
 
       return update();
-
-      // return Promise.all([
-      //   update('draft'),
-      //   update('published')
-      // ]);
-
-      // if (existingDraft && existingPublished) {
-      //   return Promise.all([
-      //     update('draft'),
-      //     update('published')
-      //   ]);
-      // }
-
-      // if (existingDraft) {
-      //   return Promise.all([
-      //     update('draft'),
-      //     update('published')
-      //   ]);
-      // }
-
-      // return update();
 
       function prepare() {
         if (!doc[updateField]) {
@@ -411,39 +390,40 @@ module.exports = self => {
       }
 
       async function update() {
-        // FIXME: use procedural code instead
-        // A complicated way to get the corresponding draft or published document.
+        const matchingDocs = [ matchingDraft, matchingPublished ].filter(Boolean);
+
+        // Get the corresponding draft or published document.
         // At this point, we know that at least one of them exists.
-        const existingDocs = Object
-          .entries({
-            draft: existingDraft,
-            published: existingPublished
-          })
-          .map(async ([ mode, existingDoc ]) => {
-            if (!existingDoc) {
-              existingDoc = await manager
-                .findForEditing(
-                  req.clone({ mode }),
-                  {
-                    aposMode: mode,
-                    aposDocId: mode === 'draft'
-                      ? existingPublished.aposDocId
-                      : existingDraft.aposDocId
-                  })
-                .toObject();
-            }
-            return existingDoc;
-          });
+        if (matchingDocs.length === 1) {
+          if (matchingDraft) {
+            matchingDocs.push(
+              await manager.findForEditing(
+                req.clone({ mode: 'published' }),
+                {
+                  aposMode: 'published',
+                  aposDocId: matchingDraft.aposDocId
+                }).toObject()
+            );
+          }
+          if (matchingPublished) {
+            matchingDocs.push(
+              await manager.findForEditing(
+                req.clone({ mode: 'draft' }),
+                {
+                  aposMode: 'draft',
+                  aposDocId: matchingPublished.aposDocId
+                }).toObject()
+            );
+          }
+        }
 
-        console.dir(existingDocs, { depth: 9 });
+        for (const docToUpdate of matchingDocs) {
+          const _req = req.clone({ mode: docToUpdate.aposMode });
 
-        for (const existingDoc of existingDocs) {
-          const _req = req.clone({ mode: existingDoc.aposMode });
+          docToUpdate.modified = false;
 
-          doc.lastPublishedAt = existingDoc.lastPublishedAt;
-
-          await manager.convert(_req, doc, existingDoc);
-          await manager.update(_req, existingDoc, { setModified: false });
+          await manager.convert(_req, doc, docToUpdate);
+          await manager.update(_req, docToUpdate, { setModified: false });
         }
       }
     },

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -102,7 +102,7 @@ module.exports = self => {
 
       const {
         duplicatedDocs, duplicatedIds, failedIds
-      } = await self.insertDocs(req, docs, moduleName, reporting);
+      } = await self.insertDocs(req, docs, reporting);
 
       const importedAttachments = await self.insertAttachments(req, {
         attachmentsInfo,
@@ -232,7 +232,7 @@ module.exports = self => {
       return locale;
     },
 
-    async insertDocs(req, docs, moduleName, reporting) {
+    async insertDocs(req, docs, reporting) {
       const duplicatedDocs = [];
       const duplicatedIds = [];
       const failedIds = [];

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -102,7 +102,7 @@ module.exports = self => {
 
       const {
         duplicatedDocs, duplicatedIds, failedIds
-      } = await self.insertDocs(req, docs, reporting);
+      } = await self.insertDocs(req, docs, moduleName, reporting);
 
       const importedAttachments = await self.insertAttachments(req, {
         attachmentsInfo,
@@ -232,12 +232,35 @@ module.exports = self => {
       return locale;
     },
 
-    async insertDocs(req, docs, reporting) {
+    async insertDocs(req, docs, moduleName, reporting) {
       const duplicatedDocs = [];
       const duplicatedIds = [];
       const failedIds = [];
 
       for (const doc of docs) {
+        if (!doc.type) {
+          doc.type = moduleName;
+        }
+
+        const { updateKey, updateField } = self.getUpdateKey(doc);
+
+        if (updateKey) {
+          try {
+            await self.insertOrUpdateDocWithKey(req, {
+              doc,
+              updateKey,
+              updateField
+            });
+            reporting.success();
+          } catch (error) {
+            reporting.failure();
+            failedIds.push(doc.aposDocId);
+            self.apos.util.error(error);
+          }
+
+          continue;
+        }
+
         const cloned = cloneDeep(doc);
 
         try {
@@ -292,6 +315,80 @@ module.exports = self => {
       };
     },
 
+    async insertOrUpdateDocWithKey(req, {
+      doc,
+      updateKey,
+      updateField
+    }) {
+      const isPage = self.apos.page.isPage(doc);
+      const manager = isPage
+        ? self.apos.page
+        : self.apos.modules[doc.type];
+
+      if (!manager) {
+        throw new Error(`No manager found for this module: ${doc.type}`);
+      }
+
+      // Import can be disable at the page-type level
+      if (!self.canImport(req, doc.type)) {
+        throw new Error(`Import is disabled for this module: ${doc.type}`);
+      }
+
+      const schema = manager.schema;
+      schema.forEach(field => {
+        if (field.options && field.options.importAsRichText) {
+          doc[field.name] = self.apos.area.fromRichText(doc[field.name]);
+        }
+      });
+
+      const updateKeyValue = updateKey && doc[updateKey];
+      if (!updateKeyValue) {
+        throw new Error(`An empty value for the "${updateKey}" update key was found in the document.`);
+      }
+
+      const existingDoc = await manager.findForEditing(req, {
+        aposMode: 'draft',
+        [updateField]: updateKeyValue
+      }).toObject();
+
+      const _req = req.clone({ mode: 'draft' }); // TODO: and publish?
+
+      // --- UPDATE ---
+
+      if (existingDoc) {
+        doc[updateField] = updateKeyValue;
+        doc.lastPublishedAt = existingDoc.lastPublishedAt;
+
+        // TODO: use manager.convert?
+        return manager.update(_req, doc, { setModified: false });
+      }
+
+      // --- INSERT ---
+
+      if (isPage) {
+        // TODO: use manager.convert?
+        return manager.insert(_req, '_home', 'lastChild', doc, { setModified: false });
+      }
+
+      // TODO: use manager.convert?
+      return manager.insert(_req, doc, { setModified: false });
+    },
+
+    getUpdateKey (doc) {
+      const [ updateKey, ...rest ] = Object
+        .keys(doc)
+        .filter(key => key.endsWith(':key'));
+
+      if (rest.length) {
+        throw new Error('You can have only one key column for updates.');
+      }
+
+      return {
+        updateKey,
+        updateField: updateKey && updateKey.replace(':key', '')
+      };
+    },
+
     async insertAttachments(req, {
       attachmentsInfo, reporting, duplicatedIds, docIds
     }) {
@@ -319,6 +416,7 @@ module.exports = self => {
       doc, method = 'insert', duplicatedIds, failedIds
     }) {
       const isPage = self.apos.page.isPage(doc);
+      console.log('🚀 ~ isPage:', isPage);
       const manager = isPage
         ? self.apos.page
         : self.apos.modules[doc.type];

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -239,6 +239,7 @@ module.exports = self => {
 
       for (const doc of docs) {
         if (!doc.type) {
+          console.log('moduleName', moduleName);
           doc.type = moduleName;
         }
 
@@ -322,11 +323,13 @@ module.exports = self => {
       updateKey,
       updateField
     }) {
-      const isPage = self.apos.page.isPage(doc);
-      const manager = isPage
-        ? self.apos.page
-        : self.apos.modules[doc.type];
+      const manager = self.apos.doc.getManager(doc.type);
       console.log('manager.__meta.name', manager.__meta.name);
+
+      // `self.apos.page.isPage` does not work here since
+      // the slug can be omitted in the CSV or Excel file.
+      const isPage = manager.__meta.chain.some(module => module.name === '@apostrophecms/page-type');
+      console.log('🚀 ~ isPage:', isPage);
 
       if (!manager) {
         throw new Error(`No manager found for this module: ${doc.type}`);
@@ -341,19 +344,24 @@ module.exports = self => {
         return insert();
       }
 
-      const matchingDraft = await manager.findForEditing(
+      const matchingDraftPromise = manager.findForEditing(
         req.clone({ mode: 'draft' }),
         {
           aposMode: 'draft',
           [updateField]: doc[updateKey]
         }).toObject();
 
-      const matchingPublished = await manager.findForEditing(
+      const matchingPublishedPromise = manager.findForEditing(
         req.clone({ mode: 'published' }),
         {
           aposMode: 'published',
           [updateField]: doc[updateKey]
         }).toObject();
+
+      let [ matchingDraft, matchingPublished ] = await Promise.all([
+        matchingDraftPromise,
+        matchingPublishedPromise
+      ]);
 
       console.log('🚀 ~ matchingDraft:', matchingDraft);
       console.log('🚀 ~ matchingPublished:', matchingPublished);
@@ -365,11 +373,14 @@ module.exports = self => {
       return update();
 
       function prepare() {
+        // Use the schema of the actual page-type module, not the page module.
+        const { schema } = self.apos.modules[doc.type];
+
         if (!doc[updateField]) {
           doc[updateField] = doc[updateKey];
         }
 
-        manager.schema.forEach(field => {
+        schema.forEach(field => {
           if (field.options && field.options.importAsRichText) {
             doc[field.name] = self.apos.area.fromRichText(doc[field.name]);
           }
@@ -383,48 +394,48 @@ module.exports = self => {
         await manager.convert(_req, doc, docToImport);
 
         if (isPage) {
-          return manager.insert(_req, '_home', 'lastChild', docToImport, { setModified: false });
+          return self.apos.page.insert(_req, '_home', 'lastChild', docToImport, { setModified: false });
         }
 
         return manager.insert(_req, docToImport, { setModified: false });
       }
 
       async function update() {
-        const matchingDocs = [ matchingDraft, matchingPublished ].filter(Boolean);
-
         // Get the corresponding draft or published document.
         // At this point, we know that at least one of them exists.
-        if (matchingDocs.length === 1) {
-          if (matchingDraft) {
-            matchingDocs.push(
-              await manager.findForEditing(
-                req.clone({ mode: 'published' }),
-                {
-                  aposMode: 'published',
-                  aposDocId: matchingDraft.aposDocId
-                }).toObject()
-            );
-          }
-          if (matchingPublished) {
-            matchingDocs.push(
-              await manager.findForEditing(
-                req.clone({ mode: 'draft' }),
-                {
-                  aposMode: 'draft',
-                  aposDocId: matchingPublished.aposDocId
-                }).toObject()
-            );
-          }
+        if (!matchingDraft) {
+          matchingDraft = await manager
+            .findForEditing(req.clone({ mode: 'draft' }), {
+              aposMode: 'draft',
+              aposDocId: matchingPublished.aposDocId
+            })
+            .toObject();
+        }
+        if (!matchingPublished) {
+          matchingPublished = await manager
+            .findForEditing(req.clone({ mode: 'published' }), {
+              aposMode: 'published',
+              aposDocId: matchingDraft.aposDocId
+            })
+            .toObject();
         }
 
-        for (const docToUpdate of matchingDocs) {
+        for (const docToUpdate of [ matchingDraft, matchingPublished ]) {
           const _req = req.clone({ mode: docToUpdate.aposMode });
 
-          docToUpdate.modified = false;
-
           await manager.convert(_req, doc, docToUpdate);
-          await manager.update(_req, docToUpdate, { setModified: false });
+          await manager.update(_req, docToUpdate);
         }
+
+        // Manually set `modified: false` because `setModified` option is not taken into account
+        // in the `update` method.
+        await self.apos.doc.db.updateOne({
+          _id: matchingDraft._id
+        }, {
+          $set: {
+            modified: false
+          }
+        });
       }
     },
 
@@ -469,6 +480,8 @@ module.exports = self => {
     async insertOrUpdateDoc(req, {
       doc, method = 'insert', duplicatedIds, failedIds
     }) {
+      // `self.apos.page.isPage` works here because the doc contains the slug
+      // since at this step, the full doc was exported.
       const isPage = self.apos.page.isPage(doc);
       console.log('🚀 ~ isPage:', isPage);
       const manager = isPage

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -243,6 +243,8 @@ module.exports = self => {
         }
 
         const { updateKey, updateField } = self.getUpdateKey(doc);
+        console.log('🚀 ~ insertDocs ~ updateField:', updateField);
+        console.log('🚀 ~ insertDocs ~ updateKey:', updateKey);
 
         if (updateKey) {
           try {
@@ -321,9 +323,11 @@ module.exports = self => {
       updateField
     }) {
       const isPage = self.apos.page.isPage(doc);
+      console.log('🚀 ~ isPage:', isPage);
       const manager = isPage
         ? self.apos.page
         : self.apos.modules[doc.type];
+      console.log('manager.__meta.name', manager.__meta.name);
 
       if (!manager) {
         throw new Error(`No manager found for this module: ${doc.type}`);
@@ -334,44 +338,65 @@ module.exports = self => {
         throw new Error(`Import is disabled for this module: ${doc.type}`);
       }
 
-      const schema = manager.schema;
-      schema.forEach(field => {
+      // FIXME: options.importAsRichText
+      manager.schema.forEach(field => {
         if (field.options && field.options.importAsRichText) {
           doc[field.name] = self.apos.area.fromRichText(doc[field.name]);
         }
       });
 
-      const updateKeyValue = updateKey && doc[updateKey];
-      if (!updateKeyValue) {
-        throw new Error(`An empty value for the "${updateKey}" update key was found in the document.`);
+      if (!doc[updateKey]) {
+        await insert(doc, 'draft');
+        await insert(doc, 'published');
       }
 
-      const existingDoc = await manager.findForEditing(req, {
-        aposMode: 'draft',
-        [updateField]: updateKeyValue
-      }).toObject();
+      for (const mode of [ 'draft', 'published' ]) {
+        const _req = req.clone({ mode });
+        const existingDoc = await manager.findForEditing(_req, {
+          aposMode: mode,
+          [updateField]: doc[updateKey]
+        }).toObject();
+        console.log('🚀 ~ mode:', mode);
+        console.log('🚀 ~ existingDoc:', existingDoc);
 
-      const _req = req.clone({ mode: 'draft' }); // TODO: and publish?
+        if (!existingDoc) {
+          await insert(doc, mode);
+        } else {
+          await update(doc, existingDoc, mode);
+        }
+      }
 
-      // --- UPDATE ---
+      async function insert(doc, mode) {
+        const _req = req.clone({ mode });
 
-      if (existingDoc) {
-        doc[updateField] = updateKeyValue;
+        const docToImport = {};
+        await manager.convert(req, doc, docToImport);
+
+        if (isPage) {
+          await manager.insert(_req, '_home', 'lastChild', docToImport, { setModified: false });
+        }
+
+        await manager.insert(_req, docToImport, { setModified: false });
+      }
+
+      async function update(doc, existingDoc, mode) {
+        console.log('🚀 ~ update ~ doc:', doc);
+        console.log('🚀 ~ update ~ existingDoc:', existingDoc);
+        const _req = req.clone({ mode });
+
         doc.lastPublishedAt = existingDoc.lastPublishedAt;
 
-        // TODO: use manager.convert?
-        return manager.update(_req, doc, { setModified: false });
+        if (!doc[updateField]) {
+          doc[updateField] = doc[updateKey];
+        }
+
+        delete doc[updateKey];
+
+        console.log('🚀 ~ update ~ doc:', doc);
+
+        await manager.convert(req, doc, existingDoc);
+        return manager.update(_req, existingDoc, { setModified: false });
       }
-
-      // --- INSERT ---
-
-      if (isPage) {
-        // TODO: use manager.convert?
-        return manager.insert(_req, '_home', 'lastChild', doc, { setModified: false });
-      }
-
-      // TODO: use manager.convert?
-      return manager.insert(_req, doc, { setModified: false });
     },
 
     getUpdateKey (doc) {

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -238,16 +238,27 @@ module.exports = self => {
       const failedIds = [];
 
       for (const doc of docs) {
-        if (!doc.type) {
-          console.log('moduleName', moduleName);
-          doc.type = moduleName;
-        }
-
         const { updateKey, updateField } = self.getUpdateKey(doc);
-        console.log('🚀 ~ insertDocs ~ updateField:', updateField);
-        console.log('🚀 ~ insertDocs ~ updateKey:', updateKey);
 
+        // If an update key is found, we try to update the document.
+        // It also means that we are in a "simple" import (CSV or Excel),
+        // not in a full import process like Gzip with JSON formats.
         if (updateKey) {
+          if (!doc.type) {
+            reporting.failure();
+            failedIds.push(doc.aposDocId);
+            await self.apos.notify(req, 'aposImportExport:typeColumnMissing', {
+              interpolate: {
+                updateKey: doc[updateKey]
+              },
+              dismiss: true,
+              icon: 'database-import-icon',
+              type: 'danger'
+            });
+            self.apos.util.error(new Error('No type found in the document.'));
+            continue;
+          }
+
           try {
             await self.insertOrUpdateDocWithKey(req, {
               doc,
@@ -324,21 +335,33 @@ module.exports = self => {
       updateField
     }) {
       const manager = self.apos.doc.getManager(doc.type);
-      console.log('manager.__meta.name', manager.__meta.name);
-
-      // `self.apos.page.isPage` does not work here since
-      // the slug can be omitted in the CSV or Excel file.
-      const isPage = manager.__meta.chain.some(module => module.name === '@apostrophecms/page-type');
-      console.log('🚀 ~ isPage:', isPage);
 
       if (!manager) {
+        await self.apos.notify(req, 'aposImportExport:typeUnknownWithUpdateKey', {
+          interpolate: {
+            type: doc.type,
+            updateKey: doc[updateKey]
+          },
+          dismiss: true,
+          icon: 'database-import-icon',
+          type: 'danger'
+        });
         throw new Error(`No manager found for this module: ${doc.type}`);
       }
+
       if (!self.canImport(req, doc.type)) {
         throw new Error(`Import is disabled for this module: ${doc.type}`);
       }
 
-      prepare();
+      // `self.apos.page.isPage` does not work here since
+      // the slug can be omitted in a CSV or Excel file.
+      const isPage = manager.__meta.chain.some(module => module.name === '@apostrophecms/page-type');
+
+      if (!doc[updateField]) {
+        doc[updateField] = doc[updateKey];
+      }
+
+      self.handleRichTextFields(manager, doc);
 
       if (!doc[updateKey]) {
         return insert();
@@ -363,29 +386,11 @@ module.exports = self => {
         matchingPublishedPromise
       ]);
 
-      console.log('🚀 ~ matchingDraft:', matchingDraft);
-      console.log('🚀 ~ matchingPublished:', matchingPublished);
-
       if (!matchingDraft && !matchingPublished) {
         return insert();
       }
 
       return update();
-
-      function prepare() {
-        // Use the schema of the actual page-type module, not the page module.
-        const { schema } = self.apos.modules[doc.type];
-
-        if (!doc[updateField]) {
-          doc[updateField] = doc[updateKey];
-        }
-
-        schema.forEach(field => {
-          if (field.options && field.options.importAsRichText) {
-            doc[field.name] = self.apos.area.fromRichText(doc[field.name]);
-          }
-        });
-      }
 
       async function insert() {
         const _req = req.clone({ mode: 'published' });
@@ -454,6 +459,14 @@ module.exports = self => {
       };
     },
 
+    handleRichTextFields(manager, doc) {
+      manager.schema.forEach(field => {
+        if (field.options && field.options.importAsRichText) {
+          doc[field.name] = self.apos.area.fromRichText(doc[field.name]);
+        }
+      });
+    },
+
     async insertAttachments(req, {
       attachmentsInfo, reporting, duplicatedIds, docIds
     }) {
@@ -480,21 +493,33 @@ module.exports = self => {
     async insertOrUpdateDoc(req, {
       doc, method = 'insert', duplicatedIds, failedIds
     }) {
-      // `self.apos.page.isPage` works here because the doc contains the slug
-      // since at this step, the full doc was exported.
-      const isPage = self.apos.page.isPage(doc);
-      console.log('🚀 ~ isPage:', isPage);
-      const manager = isPage
-        ? self.apos.page
-        : self.apos.modules[doc.type];
+      const manager = self.apos.modules[doc.type];
 
       if (!manager) {
+        await self.apos.notify(req, 'aposImportExport:typeUnknown', {
+          interpolate: {
+            type: doc.type
+          },
+          dismiss: true,
+          icon: 'database-import-icon',
+          type: 'danger'
+        });
         throw new Error(`No manager found for this module: ${doc.type}`);
       }
 
       // Import can be disable at the page-type level
       if (!self.canImport(req, doc.type)) {
         throw new Error(`Import is disabled for this module: ${doc.type}`);
+      }
+
+      // `self.apos.page.isPage` does not work here since
+      // the slug can be omitted in a CSV or Excel file.
+      const isPage = manager.__meta.chain.some(module => module.name === '@apostrophecms/page-type');
+
+      // In the case of a "simple" import (CSV or Excel), there are good chances that the
+      // `aposMode` property is not set. We set it to `draft` by default.
+      if (!doc.aposMode) {
+        doc.aposMode = 'draft';
       }
 
       if (doc.aposMode === 'published') {
@@ -511,24 +536,28 @@ module.exports = self => {
         }
       }
 
+      let docToImport = {};
       if (method === 'update' && doc.aposMode === 'draft') {
         const existingDoc = await self.apos.doc.db.findOne({ _id: doc._id }, {
           lastPublishedAt: 1
         });
         if (existingDoc) {
           doc.lastPublishedAt = existingDoc.lastPublishedAt;
+          docToImport = existingDoc;
         }
       }
 
+      self.handleRichTextFields(manager, doc);
+
       const _req = req.clone({ mode: doc.aposMode });
 
-      if (isPage) {
-        return method === 'update'
-          ? manager[method](_req, doc, { setModified: false })
-          : manager[method](_req, '_home', 'lastChild', doc, { setModified: false });
+      await manager.convert(_req, doc, docToImport);
+
+      if (method === 'insert' && isPage) {
+        return self.apos.page.insert(_req, '_home', 'lastChild', docToImport, { setModified: false });
       }
 
-      return manager[method](_req, doc, { setModified: false });
+      return manager[method](_req, docToImport, { setModified: false });
     },
 
     canImport(req, docType) {

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -353,10 +353,6 @@ module.exports = self => {
         throw new Error(`Import is disabled for this module: ${doc.type}`);
       }
 
-      // `self.apos.page.isPage` does not work here since
-      // the slug can be omitted in a CSV or Excel file.
-      const isPage = manager.__meta.chain.some(module => module.name === '@apostrophecms/page-type');
-
       if (!doc[updateField]) {
         doc[updateField] = doc[updateKey];
       }
@@ -389,20 +385,21 @@ module.exports = self => {
       if (!matchingDraft && !matchingPublished) {
         return insert();
       }
-
       return update();
 
       async function insert() {
+        // Insert as "published" to insert
+        // in both draft and published versions:
         const _req = req.clone({ mode: 'published' });
 
-        const docToImport = {};
-        await manager.convert(_req, doc, docToImport);
+        const docToInsert = {};
+        await manager.convert(_req, doc, docToInsert);
 
-        if (isPage) {
-          return self.apos.page.insert(_req, '_home', 'lastChild', docToImport, { setModified: false });
+        if (self.isPage(manager)) {
+          return self.apos.page.insert(_req, '_home', 'lastChild', docToInsert, { setModified: false });
         }
 
-        return manager.insert(_req, docToImport, { setModified: false });
+        return manager.insert(_req, docToInsert, { setModified: false });
       }
 
       async function update() {
@@ -425,22 +422,16 @@ module.exports = self => {
             .toObject();
         }
 
-        for (const docToUpdate of [ matchingDraft, matchingPublished ]) {
+        const docsToUpdate = [ matchingDraft, matchingPublished ].filter(Boolean);
+
+        for (const docToUpdate of docsToUpdate) {
           const _req = req.clone({ mode: docToUpdate.aposMode });
 
           await manager.convert(_req, doc, docToUpdate);
           await manager.update(_req, docToUpdate);
         }
 
-        // Manually set `modified: false` because `setModified` option is not taken into account
-        // in the `update` method.
-        await self.apos.doc.db.updateOne({
-          _id: matchingDraft._id
-        }, {
-          $set: {
-            modified: false
-          }
-        });
+        await self.setDocAsNotModified(matchingDraft);
       }
     },
 
@@ -512,10 +503,6 @@ module.exports = self => {
         throw new Error(`Import is disabled for this module: ${doc.type}`);
       }
 
-      // `self.apos.page.isPage` does not work here since
-      // the slug can be omitted in a CSV or Excel file.
-      const isPage = manager.__meta.chain.some(module => module.name === '@apostrophecms/page-type');
-
       // In the case of a "simple" import (CSV or Excel), there are good chances that the
       // `aposMode` property is not set. We set it to `draft` by default.
       if (!doc.aposMode) {
@@ -536,32 +523,64 @@ module.exports = self => {
         }
       }
 
-      let docToImport = {};
-      if (method === 'update' && doc.aposMode === 'draft') {
-        const existingDoc = await self.apos.doc.db.findOne({ _id: doc._id }, {
-          lastPublishedAt: 1
-        });
-        if (existingDoc) {
-          doc.lastPublishedAt = existingDoc.lastPublishedAt;
-          docToImport = existingDoc;
-        }
-      }
-
       self.handleRichTextFields(manager, doc);
 
-      const _req = req.clone({ mode: doc.aposMode });
+      if (method === 'insert') {
+        return insert();
+      }
+      return update();
 
-      await manager.convert(_req, doc, docToImport);
+      async function insert() {
+        const _req = req.clone({ mode: doc.aposMode });
 
-      if (method === 'insert' && isPage) {
-        return self.apos.page.insert(_req, '_home', 'lastChild', docToImport, { setModified: false });
+        const docToInsert = doc;
+        await manager.convert(_req, doc, docToInsert, { presentFieldsOnly: true });
+
+        if (self.isPage(manager)) {
+          return self.apos.page.insert(_req, '_home', 'lastChild', docToInsert, { setModified: false });
+        }
+
+        return manager.insert(_req, docToInsert, { setModified: false });
       }
 
-      return manager[method](_req, docToImport, { setModified: false });
+      async function update() {
+        const _req = req.clone({ mode: doc.aposMode });
+
+        if (doc.aposMode === 'draft') {
+          const existingDoc = await self.apos.doc.db.findOne({ _id: doc._id }, {
+            lastPublishedAt: 1
+          });
+          if (existingDoc) {
+            doc.lastPublishedAt = existingDoc.lastPublishedAt;
+          }
+        }
+
+        await manager.update(_req, doc);
+
+        if (doc.aposMode === 'draft') {
+          await self.setDocAsNotModified(doc);
+        }
+      }
     },
 
     canImport(req, docType) {
       return self.canImportOrExport(req, docType, 'import');
+    },
+
+    // `self.apos.page.isPage` does not work here since
+    // the slug can be omitted in a CSV or Excel file.
+    isPage(manager) {
+      return manager.__meta.chain.some(module => module.name === '@apostrophecms/page-type');
+    },
+
+    // Manually set `modified: false` because `setModified`
+    // option is not taken into account in the `update` method.
+    setDocAsNotModified(doc) {
+      return self.apos.doc.db.updateOne({ _id: doc._id }, {
+        $set: {
+          modified: false
+        }
+      });
     },
 
     async insertOrUpdateAttachment(req, {

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -493,7 +493,7 @@ module.exports = self => {
     async insertOrUpdateDoc(req, {
       doc, method = 'insert', duplicatedIds, failedIds
     }) {
-      const manager = self.apos.modules[doc.type];
+      const manager = self.apos.doc.getManager(doc.type);
 
       if (!manager) {
         await self.apos.notify(req, 'aposImportExport:typeUnknown', {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

### Adds

* Add the possibility to set a **key column** in your import CSV file in order to update existing pieces and pages.  
Thanks to this, this module reaches parity with the deprecated [`@apostrophecms/piece-type-importer`](https://github.com/apostrophecms/piece-type-importer) module.

### Fixes

* We can now import pieces or pages with an import file that contains just the required fields. Before that, CSV import files had to contain all the document attributes, which was only the case when importing a file previously exported using this module.

---

See PR comments.

- [x] TODO: fix mocha tests
- [ ] TODO: add cypress tests for the column key feature and the fix mentioned in the changelog 

## What kind of change does this PR introduce?
*(Check at least one)*

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
