### PR TITLE
Use apos.area.getWidgets instead of options.widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+* Fix export relationship when an area has grouped widgets
+
 ## 2.1.0 (2024-06-12)
 
 ### Adds

--- a/lib/apiRoutes.js
+++ b/lib/apiRoutes.js
@@ -38,7 +38,8 @@ module.exports = self => {
             return shouldRecurse && obj.schema.flatMap(searchRelationships);
           } else if (obj.type === 'area') {
             recursions++;
-            return Object.keys(obj.options.widgets).flatMap(widget => {
+            const widgets = self.apos.area.getWidgets(obj.options);
+            return Object.keys(widgets).flatMap(widget => {
               const { schema = [] } = self.apos.modules[`${widget}-widget`];
               return shouldRecurse && schema.flatMap(searchRelationships);
             });


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Fixes an issue when using grouped widgets in areas where the export function was not able to resolve relationships, giving an error on the api route.

## What are the specific steps to test this change?

On a page template that have an area with grouped widgets, try to export and ensure you're able to include related documents.

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
