### PR TITLE
Add a scrollbar to the duplicate import modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.3.0 (2024-07-24)
+## UNRELEASED
 
 ### Adds
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Adds
 
-* Add a scrollbar to the duplicate import modal 
+* Add a scrollbar to the duplicate import modal to handle too many duplicates, and fixed the "Type" column to display the correct document type.
 
 ## 2.2.0 (2024-07-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.3.0 (2024-07-24)
+
+### Adds
+
+* Add a scrollbar to the duplicate import modal 
+
 ## 2.2.0 (2024-07-12)
 
 ### Adds

--- a/ui/apos/components/AposDuplicateImportModal.vue
+++ b/ui/apos/components/AposDuplicateImportModal.vue
@@ -245,7 +245,7 @@ export default {
         : this.duplicatedDocs.map(({ aposDocId }) => aposDocId);
     },
     docLabel(doc) {
-      const moduleOptions = apos.modules[this.type];
+      const moduleOptions = apos.modules[doc.type];
 
       return moduleOptions?.label
         ? this.$t(moduleOptions?.label)

--- a/ui/apos/components/AposDuplicateImportModal.vue
+++ b/ui/apos/components/AposDuplicateImportModal.vue
@@ -326,7 +326,7 @@ export default {
   flex-direction: column;
   align-items: baseline;
   max-height: 50vh;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .apos-import-duplicate__section thead {

--- a/ui/apos/components/AposDuplicateImportModal.vue
+++ b/ui/apos/components/AposDuplicateImportModal.vue
@@ -332,7 +332,6 @@ export default {
 .apos-import-duplicate__section thead {
   position: sticky;
   top: 0;
-  z-index: 1;
   background-color: var(--a-background-primary);
 }
 

--- a/ui/apos/components/AposDuplicateImportModal.vue
+++ b/ui/apos/components/AposDuplicateImportModal.vue
@@ -325,7 +325,7 @@ export default {
   display: flex;
   flex-direction: column;
   align-items: baseline;
-  max-height: 50vh;
+  max-height: 210px;
   overflow-y: auto;
 }
 
@@ -333,7 +333,7 @@ export default {
   position: sticky;
   top: 0;
   z-index: 1;
-  backgroud-color: var(--a-base-10);
+  background-color: var(--a-background-primary);
 }
 
 .apos-import-duplicate__section .apos-table__header {

--- a/ui/apos/components/AposDuplicateImportModal.vue
+++ b/ui/apos/components/AposDuplicateImportModal.vue
@@ -22,30 +22,30 @@
           <div class="apos-import-duplicate__section">
             <table class="apos-table">
               <thead>
-                  <tr>
-                    <th class="apos-table__header">
-                      <AposButton
-                        class="apos-toggle"
-                        :class="{ 'apos-toggle--blank': !checked.length }"
-                        data-apos-test="contextMenuTrigger"
-                        type="quiet"
-                        :text-color="checkboxIconColor"
-                        :icon="checkboxIcon"
-                        :icon-only="true"
-                        :icon-size="10"
-                        @click.stop="toggle"
-                      />
-                    </th>
-                    <th class="apos-table__header">
-                      {{ $t('aposImportExport:title') }}
-                    </th>
-                    <th class="apos-table__header">
-                      {{ $t('aposImportExport:type') }}
-                    </th>
-                    <th class="apos-table__header">
-                      {{ $t('aposImportExport:lastEdited') }}
-                    </th>
-                  </tr>
+                <tr>
+                  <th class="apos-table__header">
+                    <AposButton
+                      class="apos-toggle"
+                      :class="{ 'apos-toggle--blank': !checked.length }"
+                      data-apos-test="contextMenuTrigger"
+                      type="quiet"
+                      :text-color="checkboxIconColor"
+                      :icon="checkboxIcon"
+                      :icon-only="true"
+                      :icon-size="10"
+                      @click.stop="toggle"
+                    />
+                  </th>
+                  <th class="apos-table__header">
+                    {{ $t('aposImportExport:title') }}
+                  </th>
+                  <th class="apos-table__header">
+                    {{ $t('aposImportExport:type') }}
+                  </th>
+                  <th class="apos-table__header">
+                    {{ $t('aposImportExport:lastEdited') }}
+                  </th>
+                </tr>
               </thead>
               <tbody>
                 <tr

--- a/ui/apos/components/AposDuplicateImportModal.vue
+++ b/ui/apos/components/AposDuplicateImportModal.vue
@@ -21,31 +21,33 @@
 
           <div class="apos-import-duplicate__section">
             <table class="apos-table">
+              <thead>
+                  <tr>
+                    <th class="apos-table__header">
+                      <AposButton
+                        class="apos-toggle"
+                        :class="{ 'apos-toggle--blank': !checked.length }"
+                        data-apos-test="contextMenuTrigger"
+                        type="quiet"
+                        :text-color="checkboxIconColor"
+                        :icon="checkboxIcon"
+                        :icon-only="true"
+                        :icon-size="10"
+                        @click.stop="toggle"
+                      />
+                    </th>
+                    <th class="apos-table__header">
+                      {{ $t('aposImportExport:title') }}
+                    </th>
+                    <th class="apos-table__header">
+                      {{ $t('aposImportExport:type') }}
+                    </th>
+                    <th class="apos-table__header">
+                      {{ $t('aposImportExport:lastEdited') }}
+                    </th>
+                  </tr>
+              </thead>
               <tbody>
-                <tr>
-                  <th class="apos-table__header">
-                    <AposButton
-                      class="apos-toggle"
-                      :class="{ 'apos-toggle--blank': !checked.length }"
-                      data-apos-test="contextMenuTrigger"
-                      type="quiet"
-                      :text-color="checkboxIconColor"
-                      :icon="checkboxIcon"
-                      :icon-only="true"
-                      :icon-size="10"
-                      @click.stop="toggle"
-                    />
-                  </th>
-                  <th class="apos-table__header">
-                    {{ $t('aposImportExport:title') }}
-                  </th>
-                  <th class="apos-table__header">
-                    {{ $t('aposImportExport:type') }}
-                  </th>
-                  <th class="apos-table__header">
-                    {{ $t('aposImportExport:lastEdited') }}
-                  </th>
-                </tr>
                 <tr
                   v-for="doc in duplicatedDocs"
                   :key="doc.aposDocId"
@@ -323,6 +325,15 @@ export default {
   display: flex;
   flex-direction: column;
   align-items: baseline;
+  max-height: 50vh;
+  overflow-y: scroll;
+}
+
+.apos-import-duplicate__section thead {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  backgroud-color: var(--a-base-10);
 }
 
 .apos-import-duplicate__section .apos-table__header {


### PR DESCRIPTION
## Summary

The apostrophe duplicate imports modal component displays a table of all duplicated docs, that can overflow the visible area when there are too many duplicates (> 50). To improve usability, I added a vertical scrollbar with a maximum height of 50vh to the table body and introduce a sticky thead to keep the table headers visible while scrolling.

I also fixed the type column values: Previously, only 'Page' was displayed, regardless of the actual document type. With this fix, the correct document type will now be displayed in the type column, ensuring accurate representation of each document's type.

##  What are the specific steps to test this change?

> 1. Run the website and log in as an admin
> 2. Create a page with many images (let's say more than 50). Export that page
> 3. Import the archive generated
> 4. You should now see a scrollbar in the duplicates section (the entire modal content is always visible), and correct document type displayed

## What kind of change does this PR introduce?

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
