### PR TITLE
Pro 6416 missing fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-* Exported related documents now contain the entier document and not only the projected fields. 
+* Exported related documents now contain the entire document and not only the projected fields. 
 * The `related` route also returns the related types of the exported documents related documents.
 
 ## 2.3.0 (2024-08-08)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## UNRELEASED
+
+### Fixes
+
+* Exported related documents now contain the entier document and not only the projected fields. 
+* The `related` route also returns the related types of the exported documents related documents.
+
 ## 2.3.0 (2024-08-08)
 
 ### Adds

--- a/lib/apiRoutes.js
+++ b/lib/apiRoutes.js
@@ -10,13 +10,18 @@ module.exports = self => {
           throw self.apos.error('forbidden');
         }
 
-        const type = self.apos.launder.string(req.query.type);
-        const manager = self.apos.doc.getManager(type);
-        if (!manager) {
-          throw self.apos.error('invalid');
-        }
+        const types = self.apos.launder.strings(req.query.types);
 
-        return self.getRelatedTypes(req, manager.schema);
+        const related = types.reduce((acc, type) => {
+          const manager = self.apos.doc.getManager(type);
+          if (!manager) {
+            throw self.apos.error('invalid');
+          }
+
+          return self.getRelatedTypes(req, manager.schema, acc);
+        }, []);
+
+        return related;
       }
     },
     post: {

--- a/lib/apiRoutes.js
+++ b/lib/apiRoutes.js
@@ -1,5 +1,3 @@
-const MAX_RECURSION = 10;
-
 module.exports = self => {
   if (self.options.importExport?.export === false) {
     return {};
@@ -13,41 +11,12 @@ module.exports = self => {
         }
 
         const type = self.apos.launder.string(req.query.type);
-        if (!type) {
+        const manager = self.apos.doc.getManager(type);
+        if (!manager) {
           throw self.apos.error('invalid');
         }
 
-        const { schema = [] } = self.apos.modules[type];
-
-        // Limit recursions in order to avoid the "Maximum call stack size exceeded" error
-        // if widgets or pieces are related to themselves.
-        return findSchemaRelatedTypes(schema);
-
-        function findSchemaRelatedTypes(schema, related = [], recursions = 0) {
-          recursions++;
-          if (recursions >= MAX_RECURSION) {
-            return related;
-          }
-          for (const field of schema) {
-            if (field.type === 'relationship') {
-              if (self.canExport(req, field.withType) && !related.includes(field.withType)) {
-                related.push(field.withType);
-                const relatedManager = self.apos.doc.getManager(field.withType);
-                findSchemaRelatedTypes(relatedManager.schema, related, recursions);
-              }
-            } else if ([ 'array', 'object' ].includes(field.type)) {
-              findSchemaRelatedTypes(field.schema, related, recursions);
-            } else if (field.type === 'area') {
-              const widgets = self.apos.area.getWidgets(field.options);
-              for (const widget of Object.keys(widgets)) {
-                const { schema = [] } = self.apos.modules[`${widget}-widget`];
-                findSchemaRelatedTypes(schema, related, recursions);
-              }
-            }
-          }
-
-          return related;
-        }
+        return self.getRelatedTypes(req, manager.schema);
       }
     },
     post: {

--- a/lib/apiRoutes.js
+++ b/lib/apiRoutes.js
@@ -1,3 +1,5 @@
+const MAX_RECURSION = 10;
+
 module.exports = self => {
   if (self.options.importExport?.export === false) {
     return {};
@@ -19,31 +21,32 @@ module.exports = self => {
 
         // Limit recursions in order to avoid the "Maximum call stack size exceeded" error
         // if widgets or pieces are related to themselves.
-        const maxRecursions = 10;
-        let recursions = 0;
+        return findSchemaRelatedTypes(schema);
 
-        const relatedTypes = schema
-          .flatMap(searchRelationships)
-          .filter(Boolean);
-
-        return [ ...new Set(relatedTypes) ];
-
-        function searchRelationships(obj) {
-          const shouldRecurse = recursions <= maxRecursions;
-
-          if (obj.type === 'relationship') {
-            return self.canExport(req, obj.withType) && obj.withType;
-          } else if (obj.type === 'array' || obj.type === 'object') {
-            recursions++;
-            return shouldRecurse && obj.schema.flatMap(searchRelationships);
-          } else if (obj.type === 'area') {
-            recursions++;
-            const widgets = self.apos.area.getWidgets(obj.options);
-            return Object.keys(widgets).flatMap(widget => {
-              const { schema = [] } = self.apos.modules[`${widget}-widget`];
-              return shouldRecurse && schema.flatMap(searchRelationships);
-            });
+        function findSchemaRelatedTypes(schema, related = [], recursions = 0) {
+          recursions++;
+          if (recursions >= MAX_RECURSION) {
+            return related;
           }
+          for (const field of schema) {
+            if (field.type === 'relationship') {
+              if (self.canExport(req, field.withType) && !related.includes(field.withType)) {
+                related.push(field.withType);
+                const relatedManager = self.apos.doc.getManager(field.withType);
+                findSchemaRelatedTypes(relatedManager.schema, related, recursions);
+              }
+            } else if ([ 'array', 'object' ].includes(field.type)) {
+              findSchemaRelatedTypes(field.schema, related, recursions);
+            } else if (field.type === 'area') {
+              const widgets = self.apos.area.getWidgets(field.options);
+              for (const widget of Object.keys(widgets)) {
+                const { schema = [] } = self.apos.modules[`${widget}-widget`];
+                findSchemaRelatedTypes(schema, related, recursions);
+              }
+            }
+          }
+
+          return related;
         }
       }
     },

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -343,68 +343,6 @@ module.exports = self => {
       }
     },
 
-    getRelatedDocsFromSchemaOld(
-      req,
-      {
-        doc,
-        schema,
-        type = 'relationship',
-        relatedTypes,
-        recursion = 0
-      }
-    ) {
-      return schema.flatMap(field => {
-        const fieldValue = doc[field.name];
-        const shouldRecurse = recursion <= MAX_RECURSION;
-
-        if (!fieldValue) {
-          return [];
-        }
-        if (field.withType && relatedTypes && !relatedTypes.includes(field.withType)) {
-          return [];
-        }
-        if (field.withType && !self.canExport(req, field.withType)) {
-          return [];
-        }
-
-        if (shouldRecurse && field.type === 'array') {
-          return fieldValue.flatMap((subField) => self.getRelatedDocsFromSchema(req, {
-            doc: subField,
-            schema: field.schema,
-            type,
-            relatedTypes,
-            recursion: recursion + 1
-          }));
-        }
-
-        if (shouldRecurse && field.type === 'object') {
-          return self.getRelatedDocsFromSchema(req, {
-            doc: fieldValue,
-            schema: field.schema,
-            type,
-            relatedTypes,
-            recursion: recursion + 1
-          });
-        }
-
-        if (shouldRecurse && field.type === 'area') {
-          return (fieldValue.items || []).flatMap((widget) => self.getRelatedDocsFromSchema(req, {
-            doc: widget,
-            schema: self.apos.modules[`${widget?.type}-widget`]?.schema || [],
-            type,
-            relatedTypes,
-            recursion: recursion + 1
-          }));
-        }
-
-        if (field.type === type) {
-          return Array.isArray(fieldValue) ? fieldValue : [ fieldValue ];
-        }
-
-        return [];
-      });
-    },
-
     async exportFile(req, reporting, format, data, expiration) {
       const date = dayjs().format('YYYYMMDDHHmmss');
       const filename = `${self.apos.shortName}-${req.body.type.toLowerCase()}-export-${date}${format.extension}`;

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -45,13 +45,19 @@ module.exports = self => {
         );
       }
 
-      const relatedDocs = docs.flatMap(doc =>
-        self.getRelatedDocsFromSchema(req, {
+      const relatedDocs = [];
+      for (const doc of docs) {
+        await self.getRelatedDocsFromSchema(req, {
           doc,
           schema: self.apos.modules[doc.type].schema,
-          relatedTypes
-        })
-      );
+          relatedTypes,
+          relatedDocs
+        });
+      }
+
+      console.log('relatedDocs', relatedDocs);
+
+      // Getting only IDS here??
       const allCleanDocs = [ ...self.clean(relatedDocs), ...cleanDocs ];
 
       if (!format.includeAttachments) {
@@ -198,7 +204,105 @@ module.exports = self => {
       return self.canImportOrExport(req, docType, 'export');
     },
 
-    getRelatedDocsFromSchema(
+    async getRelatedDocsFromSchema(req, {
+      doc, schema, relatedTypes, relatedDocs, type = 'relationship', recursion = 0
+    }) {
+      for (const field of schema) {
+        const fieldValue = doc[field.name];
+        const shouldRecurse = recursion <= MAX_RECURSION;
+
+        if (!fieldValue) {
+          continue;
+        }
+        if (field.withType && relatedTypes && !relatedTypes.includes(field.withType)) {
+          continue;
+        }
+        if (field.withType && !self.canExport(req, field.withType)) {
+          continue;
+        }
+
+        if (shouldRecurse && field.type === 'array') {
+          for (const subField of fieldValue) {
+            await self.getRelatedDocsFromSchema(req, {
+              doc: subField,
+              schema: field.schema,
+              type,
+              relatedTypes,
+              recursion: recursion + 1,
+              relatedDocs
+            });
+          }
+          continue;
+        }
+
+        if (shouldRecurse && field.type === 'object') {
+          await self.getRelatedDocsFromSchema(req, {
+            doc: fieldValue,
+            schema: field.schema,
+            type,
+            relatedTypes,
+            recursion: recursion + 1,
+            relatedDocs
+          });
+          continue;
+        }
+
+        if (shouldRecurse && field.type === 'area') {
+          for (const widget of (fieldValue.items || [])) {
+            await self.getRelatedDocsFromSchema(req, {
+              doc: widget,
+              schema: self.apos.modules[`${widget?.type}-widget`]?.schema || [],
+              type,
+              relatedTypes,
+              recursion: recursion + 1,
+              relatedDocs
+            });
+          }
+          continue;
+        }
+
+        if (field.type === type) {
+          if (type === 'relationship') {
+            const manager = self.apos.doc.getManager(field.withType);
+            const relatedIds = doc[field.idsStorage];
+
+            const criteria = {
+              aposDocId: { $in: relatedIds },
+              // TODO: Verify it works in all cases for widgets..
+              aposLocale: doc.aposLocale || `${req.locale}:${req.mode}`
+            };
+            const foundRelated = await manager
+              .findForEditing(req, criteria)
+              .permission('view')
+              .relationships(false)
+              .areas(false)
+              .toArray();
+
+            for (const related of foundRelated) {
+              const alreadyAdded = relatedDocs.some(({ _id }) => _id === related._id);
+
+              if (!alreadyAdded) {
+                relatedDocs.push(self.apos.util.clonePermanent(related));
+                await self.getRelatedDocsFromSchema(req, {
+                  doc: related,
+                  schema: manager.schema,
+                  type: field.withType,
+                  relatedTypes,
+                  recursion: recursion + 1,
+                  relatedDocs
+                });
+              }
+            }
+
+            continue;
+          }
+
+          // TODO: Handle attachments
+        }
+      }
+    },
+
+    getRelatedDocsFromSchemaOld(
       req,
       {
         doc,

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -464,21 +464,23 @@ module.exports = self => {
       }, ms);
     },
 
-    getRelatedTypes(req, schema = []) {
-      return findSchemaRelatedTypes(schema);
+    getRelatedTypes(req, schema = [], related = []) {
+      return findSchemaRelatedTypes(schema, related);
 
-      function findSchemaRelatedTypes(schema, related = [], recursions = 0) {
+      function findSchemaRelatedTypes(schema, related, recursions = 0) {
         recursions++;
         if (recursions >= MAX_RECURSION) {
           return related;
         }
         for (const field of schema) {
-          if (field.type === 'relationship') {
-            if (self.canExport(req, field.withType) && !related.includes(field.withType)) {
-              related.push(field.withType);
-              const relatedManager = self.apos.doc.getManager(field.withType);
-              findSchemaRelatedTypes(relatedManager.schema, related, recursions);
-            }
+          if (
+            field.type === 'relationship' &&
+            self.canExport(req, field.withType) &&
+            !related.includes(field.withType)
+          ) {
+            related.push(field.withType);
+            const relatedManager = self.apos.doc.getManager(field.withType);
+            findSchemaRelatedTypes(relatedManager.schema, related, recursions);
           } else if ([ 'array', 'object' ].includes(field.type)) {
             findSchemaRelatedTypes(field.schema, related, recursions);
           } else if (field.type === 'area') {

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -465,8 +465,6 @@ module.exports = self => {
     },
 
     getRelatedTypes(req, schema = []) {
-      // Limit recursions in order to avoid the "Maximum call stack size exceeded" error
-      // if widgets or pieces are related to themselves.
       return findSchemaRelatedTypes(schema);
 
       function findSchemaRelatedTypes(schema, related = [], recursions = 0) {

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -32,51 +32,53 @@ module.exports = self => {
       }
 
       const hasRelatedTypes = !!relatedTypes.length;
-      const docs = await self.getDocs(req, ids, hasRelatedTypes, manager, reporting);
-      const cleanDocs = self.clean(docs);
+      const docs = await self
+        .getDocs(req, ids, hasRelatedTypes, manager, reporting)
+        .map((doc) => self.apos.util.clonePermanent(doc));
+
+      console.log('docs', docs);
 
       if (!hasRelatedTypes) {
         return self.exportFile(
           req,
           reporting,
           format,
-          { docs: cleanDocs },
+          { docs },
           expiration
         );
       }
 
-      const relatedDocs = [];
+      const allDocs = [ ...docs ];
       for (const doc of docs) {
         await self.getRelatedDocsFromSchema(req, {
           doc,
           schema: self.apos.modules[doc.type].schema,
           relatedTypes,
-          relatedDocs
+          storedData: allDocs
         });
       }
-
-      // Getting only IDS here??
-      const allCleanDocs = [ ...self.clean(relatedDocs), ...cleanDocs ];
 
       if (!format.includeAttachments) {
         return self.exportFile(
           req,
           reporting,
           format,
-          { docs: allCleanDocs },
+          { docs: allDocs },
           expiration
         );
       }
 
-      const attachmentsIds = uniqBy([ ...docs, ...relatedDocs ], doc => doc._id)
-        .flatMap(doc =>
-          self.getRelatedDocsFromSchema(req, {
-            doc,
-            schema: self.apos.modules[doc.type].schema,
-            type: 'attachment'
-          })
-        )
-        .map(attachment => attachment._id);
+      const attachmentsIds = [];
+      for (const doc of allDocs) {
+        self.getRelatedDocsFromSchema(req, {
+          doc,
+          schema: self.apos.modules[doc.type].schema,
+          type: 'attachment',
+          storedData: attachmentsIds
+        });
+      }
+
+      console.log('attachmentsIds', attachmentsIds);
 
       const attachments = await self.getAttachments(attachmentsIds);
       const cleanAttachments = self.clean(attachments);
@@ -96,7 +98,7 @@ module.exports = self => {
         reporting,
         format,
         {
-          docs: allCleanDocs,
+          docs: allDocs,
           attachments: cleanAttachments,
           attachmentUrls
         },
@@ -203,7 +205,7 @@ module.exports = self => {
     },
 
     async getRelatedDocsFromSchema(req, {
-      doc, schema, relatedTypes = [], relatedDocs, type = 'relationship', recursion = 0
+      doc, schema, relatedTypes = [], storedData, type = 'relationship', recursion = 0
     }) {
 
       recursion++;
@@ -230,7 +232,7 @@ module.exports = self => {
               type,
               relatedTypes,
               recursion,
-              relatedDocs
+              storedData
             });
           }
           continue;
@@ -243,7 +245,7 @@ module.exports = self => {
             type,
             relatedTypes,
             recursion,
-            relatedDocs
+            storedData
           });
           continue;
         }
@@ -256,68 +258,75 @@ module.exports = self => {
               type,
               relatedTypes,
               recursion,
-              relatedDocs
+              storedData
             });
           }
           continue;
         }
 
         if (field.type === type) {
-          if (type === 'relationship') {
-
-            const manager = self.apos.doc.getManager(field.withType);
-            const relatedIds = doc[field.idsStorage];
-
-            if (!relatedIds?.length) {
-              continue;
-            }
-            const criteria = {
-              aposDocId: { $in: relatedIds },
-              // TODO: Verify it works in all cases for widgets..
-              aposLocale: doc.aposLocale || `${req.locale}:${req.mode}`
-            };
-            console.log('doc.title', doc.title);
-            console.log('doc.aposLocale', doc.aposLocale);
-            console.log('criteria', criteria);
-            const foundRelated = await manager
-              .findForEditing(req, criteria)
-              .permission('view')
-              .relationships(false)
-              .areas(false)
-              .toArray();
-
-            for (const related of foundRelated) {
-              console.log('related.title', related.title);
-              console.log('related.aposLocale', related.aposLocale);
-            }
-
-            for (const related of foundRelated) {
-              const alreadyAdded = relatedDocs.some(({ _id }) => _id === related._id);
-
-              if (!alreadyAdded) {
-                relatedDocs.push(self.apos.util.clonePermanent(related));
-
-                if (!shouldRecurse) {
-                  continue;
-                }
-
-                const relatedManager = self.apos.doc.getManager(related.type);
-                await self.getRelatedDocsFromSchema(req, {
-                  doc: related,
-                  schema: relatedManager.schema,
-                  type,
-                  relatedTypes,
-                  recursion,
-                  relatedDocs
-                });
-              }
-            }
-
-            continue;
-          }
-
-          // TODO: Handle attachments
+          await self.handleRelatedField(req, {
+            doc,
+            field,
+            fieldValue,
+            relatedTypes,
+            type,
+            storedData,
+            shouldRecurse,
+            recursion
+          });
         }
+
+      }
+    },
+
+    async handleRelatedField(req, {
+      doc, field, fieldValue, relatedTypes, type, storedData, shouldRecurse, recursion
+    }) {
+      if (type === 'attachment') {
+        if (fieldValue && !storedData.includes(fieldValue._id)) {
+          storedData.push(fieldValue._id);
+        }
+        return;
+      }
+
+      const manager = self.apos.doc.getManager(field.withType);
+      const relatedIds = doc[field.idsStorage];
+      if (!relatedIds?.length) {
+        return;
+      }
+      const criteria = {
+        aposDocId: { $in: relatedIds },
+        // TODO: Verify it works in all cases for widgets..
+        aposLocale: doc.aposLocale || `${req.locale}:${req.mode}`
+      };
+      const foundRelated = await manager
+        .findForEditing(req, criteria)
+        .permission('view')
+        .relationships(false)
+        .areas(false)
+        .toArray();
+
+      for (const related of foundRelated) {
+        const alreadyAdded = storedData.some(({ _id }) => _id === related._id);
+        if (alreadyAdded) {
+          continue;
+        }
+
+        storedData.push(self.apos.util.clonePermanent(related));
+        if (!shouldRecurse) {
+          continue;
+        }
+
+        const relatedManager = self.apos.doc.getManager(related.type);
+        await self.getRelatedDocsFromSchema(req, {
+          doc: related,
+          schema: relatedManager.schema,
+          type,
+          relatedTypes,
+          recursion,
+          storedData
+        });
       }
     },
 

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -201,7 +201,13 @@ module.exports = self => {
     },
 
     async getRelatedDocsFromSchema(req, {
-      doc, schema, relatedTypes, storedData, type = 'relationship', recursion = 0
+      doc,
+      schema,
+      relatedTypes,
+      storedData,
+      type = 'relationship',
+      recursion = 0,
+      mode = doc.aposMode || req.mode
     }) {
       recursion++;
       for (const field of schema) {
@@ -226,7 +232,8 @@ module.exports = self => {
               type,
               relatedTypes,
               recursion,
-              storedData
+              storedData,
+              mode
             });
           }
           continue;
@@ -239,7 +246,8 @@ module.exports = self => {
             type,
             relatedTypes,
             recursion,
-            storedData
+            storedData,
+            mode
           });
           continue;
         }
@@ -253,7 +261,8 @@ module.exports = self => {
               type,
               relatedTypes,
               recursion,
-              storedData
+              storedData,
+              mode
             });
           }
           continue;
@@ -268,14 +277,23 @@ module.exports = self => {
             type,
             storedData,
             shouldRecurse,
-            recursion
+            recursion,
+            mode
           });
         }
       }
     },
 
     async handleRelatedField(req, {
-      doc, field, fieldValue, relatedTypes, type, storedData, shouldRecurse, recursion
+      doc,
+      field,
+      fieldValue,
+      relatedTypes,
+      type,
+      storedData,
+      shouldRecurse,
+      recursion,
+      mode
     }) {
       if (type === 'attachment') {
         if (fieldValue && !storedData.includes(fieldValue._id)) {
@@ -291,10 +309,10 @@ module.exports = self => {
       }
       const criteria = {
         aposDocId: { $in: relatedIds },
-        aposLocale: doc.aposLocale || `${req.locale}:${req.mode}`
+        aposLocale: doc.aposLocale || `${req.locale}:${mode}`
       };
 
-      const clonedReq = doc.aposMode ? req.clone({ mode: doc.aposMode }) : req;
+      const clonedReq = mode ? req.clone({ mode }) : req;
       const foundRelated = await manager
         .findForEditing(clonedReq, criteria)
         .permission('view')

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -56,6 +56,8 @@ module.exports = self => {
         });
       }
 
+      console.log('allDocs', allDocs);
+
       if (!format.includeAttachments) {
         return self.exportFile(
           req,
@@ -75,6 +77,7 @@ module.exports = self => {
           storedData: attachmentsIds
         });
       }
+      console.log('attachmentsIds', attachmentsIds);
 
       const attachments = await self.getAttachments(attachmentsIds);
       const cleanAttachments = self.clean(attachments);
@@ -203,7 +206,9 @@ module.exports = self => {
     async getRelatedDocsFromSchema(req, {
       doc, schema, relatedTypes = [], storedData, type = 'relationship', recursion = 0
     }) {
-
+      if (doc.metaType === 'widget') {
+        console.log('schema', schema);
+      }
       recursion++;
       for (const field of schema) {
         const fieldValue = doc[field.name];
@@ -248,9 +253,10 @@ module.exports = self => {
 
         if (shouldRecurse && field.type === 'area') {
           for (const widget of (fieldValue.items || [])) {
+            const schema = self.apos.modules[`${widget?.type}-widget`]?.schema || [];
             await self.getRelatedDocsFromSchema(req, {
               doc: widget,
-              schema: self.apos.modules[`${widget?.type}-widget`]?.schema || [],
+              schema,
               type,
               relatedTypes,
               recursion,
@@ -272,14 +278,18 @@ module.exports = self => {
             recursion
           });
         }
-
       }
     },
 
     async handleRelatedField(req, {
       doc, field, fieldValue, relatedTypes, type, storedData, shouldRecurse, recursion
     }) {
+      console.log('type', type);
+      console.log('type', type);
+      console.log('type', type);
+      console.log('type', type);
       if (type === 'attachment') {
+        console.log('fieldValue', fieldValue);
         if (fieldValue && !storedData.includes(fieldValue._id)) {
           storedData.push(fieldValue._id);
         }

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -276,12 +276,20 @@ module.exports = self => {
               // TODO: Verify it works in all cases for widgets..
               aposLocale: doc.aposLocale || `${req.locale}:${req.mode}`
             };
+            console.log('doc.title', doc.title);
+            console.log('doc.aposLocale', doc.aposLocale);
+            console.log('criteria', criteria);
             const foundRelated = await manager
               .findForEditing(req, criteria)
               .permission('view')
               .relationships(false)
               .areas(false)
               .toArray();
+
+            for (const related of foundRelated) {
+              console.log('related.title', related.title);
+              console.log('related.aposLocale', related.aposLocale);
+            }
 
             for (const related of foundRelated) {
               const alreadyAdded = relatedDocs.some(({ _id }) => _id === related._id);

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -56,8 +56,6 @@ module.exports = self => {
         });
       }
 
-      console.log('allDocs', allDocs);
-
       if (!format.includeAttachments) {
         return self.exportFile(
           req,
@@ -77,7 +75,6 @@ module.exports = self => {
           storedData: attachmentsIds
         });
       }
-      console.log('attachmentsIds', attachmentsIds);
 
       const attachments = await self.getAttachments(attachmentsIds);
       const cleanAttachments = self.clean(attachments);
@@ -204,21 +201,17 @@ module.exports = self => {
     },
 
     async getRelatedDocsFromSchema(req, {
-      doc, schema, relatedTypes = [], storedData, type = 'relationship', recursion = 0
+      doc, schema, relatedTypes, storedData, type = 'relationship', recursion = 0
     }) {
-      if (doc.metaType === 'widget') {
-        console.log('schema', schema);
-      }
       recursion++;
       for (const field of schema) {
         const fieldValue = doc[field.name];
         const shouldRecurse = recursion <= MAX_RECURSION;
 
-        // TODO Check it's enough for attachments too
         if (!field.withType && !fieldValue) {
           continue;
         }
-        if (field.withType && !relatedTypes.includes(field.withType)) {
+        if (field.withType && relatedTypes && !relatedTypes.includes(field.withType)) {
           continue;
         }
         if (field.withType && !self.canExport(req, field.withType)) {
@@ -284,12 +277,7 @@ module.exports = self => {
     async handleRelatedField(req, {
       doc, field, fieldValue, relatedTypes, type, storedData, shouldRecurse, recursion
     }) {
-      console.log('type', type);
-      console.log('type', type);
-      console.log('type', type);
-      console.log('type', type);
       if (type === 'attachment') {
-        console.log('fieldValue', fieldValue);
         if (fieldValue && !storedData.includes(fieldValue._id)) {
           storedData.push(fieldValue._id);
         }
@@ -303,11 +291,10 @@ module.exports = self => {
       }
       const criteria = {
         aposDocId: { $in: relatedIds },
-        // TODO: Verify it works in all cases for widgets..
         aposLocale: doc.aposLocale || `${req.locale}:${req.mode}`
       };
 
-      const clonedReq = req.clone({ mode: doc.aposMode });
+      const clonedReq = doc.aposMode ? req.clone({ mode: doc.aposMode }) : req;
       const foundRelated = await manager
         .findForEditing(clonedReq, criteria)
         .permission('view')

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -266,6 +266,9 @@ module.exports = self => {
             const manager = self.apos.doc.getManager(field.withType);
             const relatedIds = doc[field.idsStorage];
 
+            if (!relatedIds || !relatedIds.length) {
+              continue;
+            }
             const criteria = {
               aposDocId: { $in: relatedIds },
               // TODO: Verify it works in all cases for widgets..

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -32,11 +32,9 @@ module.exports = self => {
       }
 
       const hasRelatedTypes = !!relatedTypes.length;
-      const docs = await self
-        .getDocs(req, ids, hasRelatedTypes, manager, reporting)
-        .map((doc) => self.apos.util.clonePermanent(doc));
 
-      console.log('docs', docs);
+      const docs = (await self.getDocs(req, ids, hasRelatedTypes, manager, reporting))
+        .map((doc) => self.apos.util.clonePermanent(doc));
 
       if (!hasRelatedTypes) {
         return self.exportFile(
@@ -70,15 +68,13 @@ module.exports = self => {
 
       const attachmentsIds = [];
       for (const doc of allDocs) {
-        self.getRelatedDocsFromSchema(req, {
+        await self.getRelatedDocsFromSchema(req, {
           doc,
           schema: self.apos.modules[doc.type].schema,
           type: 'attachment',
           storedData: attachmentsIds
         });
       }
-
-      console.log('attachmentsIds', attachmentsIds);
 
       const attachments = await self.getAttachments(attachmentsIds);
       const cleanAttachments = self.clean(attachments);
@@ -511,6 +507,38 @@ module.exports = self => {
           }
         });
       }, ms);
+    },
+
+    getRelatedTypes(req, schema = []) {
+      // Limit recursions in order to avoid the "Maximum call stack size exceeded" error
+      // if widgets or pieces are related to themselves.
+      return findSchemaRelatedTypes(schema);
+
+      function findSchemaRelatedTypes(schema, related = [], recursions = 0) {
+        recursions++;
+        if (recursions >= MAX_RECURSION) {
+          return related;
+        }
+        for (const field of schema) {
+          if (field.type === 'relationship') {
+            if (self.canExport(req, field.withType) && !related.includes(field.withType)) {
+              related.push(field.withType);
+              const relatedManager = self.apos.doc.getManager(field.withType);
+              findSchemaRelatedTypes(relatedManager.schema, related, recursions);
+            }
+          } else if ([ 'array', 'object' ].includes(field.type)) {
+            findSchemaRelatedTypes(field.schema, related, recursions);
+          } else if (field.type === 'area') {
+            const widgets = self.apos.area.getWidgets(field.options);
+            for (const widget of Object.keys(widgets)) {
+              const { schema = [] } = self.apos.modules[`${widget}-widget`];
+              findSchemaRelatedTypes(schema, related, recursions);
+            }
+          }
+        }
+
+        return related;
+      }
     }
   };
 };

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -296,8 +296,10 @@ module.exports = self => {
         // TODO: Verify it works in all cases for widgets..
         aposLocale: doc.aposLocale || `${req.locale}:${req.mode}`
       };
+
+      const clonedReq = req.clone({ mode: doc.aposMode });
       const foundRelated = await manager
-        .findForEditing(req, criteria)
+        .findForEditing(clonedReq, criteria)
         .permission('view')
         .relationships(false)
         .areas(false)

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -55,8 +55,6 @@ module.exports = self => {
         });
       }
 
-      console.log('relatedDocs', relatedDocs);
-
       // Getting only IDS here??
       const allCleanDocs = [ ...self.clean(relatedDocs), ...cleanDocs ];
 
@@ -205,16 +203,19 @@ module.exports = self => {
     },
 
     async getRelatedDocsFromSchema(req, {
-      doc, schema, relatedTypes, relatedDocs, type = 'relationship', recursion = 0
+      doc, schema, relatedTypes = [], relatedDocs, type = 'relationship', recursion = 0
     }) {
+
+      recursion++;
       for (const field of schema) {
         const fieldValue = doc[field.name];
         const shouldRecurse = recursion <= MAX_RECURSION;
 
-        if (!fieldValue) {
+        // TODO Check it's enough for attachments too
+        if (!field.withType && !fieldValue) {
           continue;
         }
-        if (field.withType && relatedTypes && !relatedTypes.includes(field.withType)) {
+        if (field.withType && !relatedTypes.includes(field.withType)) {
           continue;
         }
         if (field.withType && !self.canExport(req, field.withType)) {
@@ -228,7 +229,7 @@ module.exports = self => {
               schema: field.schema,
               type,
               relatedTypes,
-              recursion: recursion + 1,
+              recursion,
               relatedDocs
             });
           }
@@ -241,7 +242,7 @@ module.exports = self => {
             schema: field.schema,
             type,
             relatedTypes,
-            recursion: recursion + 1,
+            recursion,
             relatedDocs
           });
           continue;
@@ -254,7 +255,7 @@ module.exports = self => {
               schema: self.apos.modules[`${widget?.type}-widget`]?.schema || [],
               type,
               relatedTypes,
-              recursion: recursion + 1,
+              recursion,
               relatedDocs
             });
           }
@@ -263,10 +264,11 @@ module.exports = self => {
 
         if (field.type === type) {
           if (type === 'relationship') {
+
             const manager = self.apos.doc.getManager(field.withType);
             const relatedIds = doc[field.idsStorage];
 
-            if (!relatedIds || !relatedIds.length) {
+            if (!relatedIds?.length) {
               continue;
             }
             const criteria = {
@@ -286,12 +288,18 @@ module.exports = self => {
 
               if (!alreadyAdded) {
                 relatedDocs.push(self.apos.util.clonePermanent(related));
+
+                if (!shouldRecurse) {
+                  continue;
+                }
+
+                const relatedManager = self.apos.doc.getManager(related.type);
                 await self.getRelatedDocsFromSchema(req, {
                   doc: related,
-                  schema: manager.schema,
-                  type: field.withType,
+                  schema: relatedManager.schema,
+                  type,
                   relatedTypes,
-                  recursion: recursion + 1,
+                  recursion,
                   relatedDocs
                 });
               }

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -743,23 +743,25 @@ module.exports = self => {
       for (const doc of filterDocs) {
         try {
           if (attachmentsInfo.length) {
-            const attachmentsToOverride = self.getRelatedDocsFromSchema(req, {
+            const attachmentsIds = [];
+            await self.getRelatedDocsFromSchema(req, {
               doc,
               schema: self.apos.modules[doc.type].schema,
-              type: 'attachment'
+              type: 'attachment',
+              storedData: attachmentsIds
             });
 
-            for (const { _id } of attachmentsToOverride) {
-              if (importedAttachments.includes(_id)) {
+            for (const id of attachmentsIds) {
+              if (importedAttachments.includes(id)) {
                 continue;
               }
               const attachmentInfo = attachmentsInfo
-                .find(({ attachment }) => attachment._id === _id);
+                .find(({ attachment }) => attachment._id === id);
 
               try {
                 await self.insertOrUpdateAttachment(req, { attachmentInfo });
                 jobManager.success(job);
-                importedAttachments.push(_id);
+                importedAttachments.push(id);
               } catch (err) {
                 jobManager.failure(job);
               }

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -109,6 +109,7 @@ module.exports = self => {
         failedIds
       });
 
+      console.log('docs', docs);
       const { duplicatedDocs, duplicatedIds } = await self.checkDuplicates(req, {
         reporting,
         docs,
@@ -321,7 +322,7 @@ module.exports = self => {
             continue;
           }
         }
-        if (aposDocId) {
+        if (aposDocId && !docIds.includes(aposDocId)) {
           docIds.push(aposDocId);
         }
       }

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -109,7 +109,6 @@ module.exports = self => {
         failedIds
       });
 
-      console.log('docs', docs);
       const { duplicatedDocs, duplicatedIds } = await self.checkDuplicates(req, {
         reporting,
         docs,

--- a/test/index.js
+++ b/test/index.js
@@ -120,10 +120,17 @@ describe('@apostrophecms/import-export', function () {
       aposMode
     }));
 
+    const topicsContainNonProjectedFields = docs
+      .filter(({ type }) => type === 'topic')
+      .every(({
+        createdAt, titleSortified, aposLocale
+      }) => createdAt && titleSortified && aposLocale);
+
     const actual = {
       docsNames,
       attachmentsLength: attachments.length,
-      attachmentFiles
+      attachmentFiles,
+      topicsContainNonProjectedFields
     };
 
     const expected = {
@@ -170,7 +177,8 @@ describe('@apostrophecms/import-export', function () {
         }
       ],
       attachmentsLength: 1,
-      attachmentFiles: [ `${attachmentId}-test-image.jpg` ]
+      attachmentFiles: [ `${attachmentId}-test-image.jpg` ],
+      topicsContainNonProjectedFields: true
     };
 
     assert.deepEqual(actual, expected);

--- a/test/index.js
+++ b/test/index.js
@@ -125,6 +125,7 @@ describe('@apostrophecms/import-export', function () {
       attachmentsLength: attachments.length,
       attachmentFiles
     };
+
     const expected = {
       docsNames: [
         {
@@ -175,8 +176,7 @@ describe('@apostrophecms/import-export', function () {
     assert.deepEqual(actual, expected);
   });
 
-  // FIX
-  it.only('should generate a zip file for pages with related documents', async function () {
+  it('should generate a zip file for pages with related documents', async function () {
     const req = apos.task.getReq();
     const page1 = await apos.page.find(req, { title: 'page1' }).toObject();
     const { _id: attachmentId } = await apos.attachment.db.findOne({ name: 'test-image' });
@@ -211,6 +211,14 @@ describe('@apostrophecms/import-export', function () {
       docsNames: [
         {
           aposMode: 'draft',
+          title: 'page1'
+        },
+        {
+          aposMode: 'published',
+          title: 'page1'
+        },
+        {
+          aposMode: 'draft',
           title: 'image1'
         },
         {
@@ -224,14 +232,6 @@ describe('@apostrophecms/import-export', function () {
         {
           aposMode: 'published',
           title: 'article2'
-        },
-        {
-          aposMode: 'draft',
-          title: 'page1'
-        },
-        {
-          aposMode: 'published',
-          title: 'page1'
         }
       ],
       attachmentsLength: 1,
@@ -241,7 +241,6 @@ describe('@apostrophecms/import-export', function () {
     assert.deepEqual(actual, expected);
   });
 
-  // FIX
   it('should import pieces with related documents from a compressed file', async function() {
     const req = apos.task.getReq();
     const articles = await apos.article.find(req).toArray();
@@ -313,12 +312,12 @@ describe('@apostrophecms/import-export', function () {
           name: 'test-image',
           type: 'attachment'
         } ],
-      docsLength: 8,
+      docsLength: 10,
       docsTitles: [
         'article2', 'article1',
         'article2', 'article1',
-        'topic1', 'topic2',
-        'topic1', 'topic2'
+        'topic1', 'topic3', 'topic2',
+        'topic1', 'topic3', 'topic2'
       ],
       attachmentsNames: [ 'test-image' ],
       attachmentFileNames: new Array(apos.attachment.imageSizes.length + 1)
@@ -328,7 +327,6 @@ describe('@apostrophecms/import-export', function () {
     assert.deepEqual(actual, expected);
   });
 
-  // FIX
   it('should return duplicates pieces when already existing and override them', async function() {
     const req = apos.task.getReq();
     const articles = await apos.article.find(req).toArray();
@@ -377,8 +375,13 @@ describe('@apostrophecms/import-export', function () {
     }
 
     delete req.files;
+
+    // Overrides all docs excepted topic3
+    const docIds = duplicatedDocs
+      .filter((doc) => doc.title !== 'topic3')
+      .map(({ aposDocId }) => aposDocId);
     req.body = {
-      docIds: duplicatedDocs.map(({ aposDocId }) => aposDocId),
+      docIds,
       importedAttachments,
       exportPathId,
       jobId,
@@ -428,14 +431,13 @@ describe('@apostrophecms/import-export', function () {
         .fill('test-image'),
       job: {
         good: 9,
-        total: 9
+        total: 11
       }
     };
 
     assert.deepEqual(actual, expected);
   });
 
-  // FIX
   it('should import page and related documents', async function() {
     const req = apos.task.getReq();
     const page1 = await apos.page.find(req, { title: 'page1' }).toObject();
@@ -489,7 +491,6 @@ describe('@apostrophecms/import-export', function () {
     assert.deepEqual(actual, expected);
   });
 
-  // FIX
   it('should return existing duplicated docs during page import and override them', async function() {
     const req = apos.task.getReq();
     const page1 = await apos.page.find(req, { title: 'page1' }).toObject();
@@ -594,7 +595,6 @@ describe('@apostrophecms/import-export', function () {
     assert.deepEqual(actual, expected);
   });
 
-  // FIX
   it('should not override attachment if associated document is not imported', async function() {
     const req = apos.task.getReq();
     const page1 = await apos.page.find(req, { title: 'page1' }).toObject();

--- a/test/index.js
+++ b/test/index.js
@@ -764,6 +764,24 @@ describe('@apostrophecms/import-export', function () {
     }), true, `expected imported docs 'lastPublishedAt' value to be of '${lastPublishedAt}'`);
   });
 
+  it('should get related types of a given doc type', async function() {
+    const req = apos.task.getReq();
+    const relatedTypesArticles = importExportManager.getRelatedTypes(req, apos.article.schema);
+    const relatedTypesTopics = importExportManager.getRelatedTypes(req, apos.topic.schema);
+
+    const actual = {
+      relatedTypesArticles,
+      relatedTypesTopics
+    };
+    const expected = {
+      relatedTypesArticles: [ 'topic', '@apostrophecms/image', '@apostrophecms/image-tag' ],
+      relatedTypesTopics: [ 'topic' ]
+    };
+
+    assert.deepEqual(actual, expected);
+
+  });
+
   describe('#getFirstDifferentLocale', function() {
     it('should find among the docs the first locale that is different from the req one', async function() {
       const req = {

--- a/test/index.js
+++ b/test/index.js
@@ -115,48 +115,57 @@ describe('@apostrophecms/import-export', function () {
       docs, attachments, attachmentFiles
     } = await getExtractedFiles(exportPath);
 
+    const docsNames = docs.map(({ title, aposMode }) => ({
+      title,
+      aposMode
+    }));
+
     const actual = {
-      docsNames: docs.map(({ title, aposMode }) => ({
-        title,
-        aposMode
-      })),
+      docsNames,
       attachmentsLength: attachments.length,
       attachmentFiles
     };
     const expected = {
       docsNames: [
         {
-          aposMode: 'draft',
-          title: 'topic1'
+          title: 'article2',
+          aposMode: 'draft'
         },
         {
-          aposMode: 'draft',
-          title: 'topic2'
+          title: 'article1',
+          aposMode: 'draft'
         },
         {
-          aposMode: 'published',
-          title: 'topic1'
+          title: 'article2',
+          aposMode: 'published'
         },
         {
-          aposMode: 'published',
-          title: 'topic2'
+          title: 'article1',
+          aposMode: 'published'
         },
         {
-          aposMode: 'draft',
-          title: 'article2'
+          title: 'topic1',
+          aposMode: 'draft'
         },
         {
-          aposMode: 'draft',
-          title: 'article1'
+          title: 'topic3',
+          aposMode: 'draft'
         },
         {
-          aposMode: 'published',
-          title: 'article2'
+          title: 'topic2',
+          aposMode: 'draft'
         },
-
         {
-          aposMode: 'published',
-          title: 'article1'
+          title: 'topic1',
+          aposMode: 'published'
+        },
+        {
+          title: 'topic3',
+          aposMode: 'published'
+        },
+        {
+          title: 'topic2',
+          aposMode: 'published'
         }
       ],
       attachmentsLength: 1,
@@ -166,7 +175,8 @@ describe('@apostrophecms/import-export', function () {
     assert.deepEqual(actual, expected);
   });
 
-  it('should generate a zip file for pages with related documents', async function () {
+  // FIX
+  it.only('should generate a zip file for pages with related documents', async function () {
     const req = apos.task.getReq();
     const page1 = await apos.page.find(req, { title: 'page1' }).toObject();
     const { _id: attachmentId } = await apos.attachment.db.findOne({ name: 'test-image' });
@@ -231,6 +241,7 @@ describe('@apostrophecms/import-export', function () {
     assert.deepEqual(actual, expected);
   });
 
+  // FIX
   it('should import pieces with related documents from a compressed file', async function() {
     const req = apos.task.getReq();
     const articles = await apos.article.find(req).toArray();
@@ -317,6 +328,7 @@ describe('@apostrophecms/import-export', function () {
     assert.deepEqual(actual, expected);
   });
 
+  // FIX
   it('should return duplicates pieces when already existing and override them', async function() {
     const req = apos.task.getReq();
     const articles = await apos.article.find(req).toArray();
@@ -423,6 +435,7 @@ describe('@apostrophecms/import-export', function () {
     assert.deepEqual(actual, expected);
   });
 
+  // FIX
   it('should import page and related documents', async function() {
     const req = apos.task.getReq();
     const page1 = await apos.page.find(req, { title: 'page1' }).toObject();
@@ -476,6 +489,7 @@ describe('@apostrophecms/import-export', function () {
     assert.deepEqual(actual, expected);
   });
 
+  // FIX
   it('should return existing duplicated docs during page import and override them', async function() {
     const req = apos.task.getReq();
     const page1 = await apos.page.find(req, { title: 'page1' }).toObject();
@@ -580,6 +594,7 @@ describe('@apostrophecms/import-export', function () {
     assert.deepEqual(actual, expected);
   });
 
+  // FIX
   it('should not override attachment if associated document is not imported', async function() {
     const req = apos.task.getReq();
     const page1 = await apos.page.find(req, { title: 'page1' }).toObject();

--- a/test/util/index.js
+++ b/test/util/index.js
@@ -237,7 +237,6 @@ async function insertPiecesAndPages(apos) {
     jar
   });
 
-  console.log('image1', image1);
   await apos.page.insert(req, '_home', 'lastChild', {
     ...pageInstance,
     title: 'page1',

--- a/test/util/index.js
+++ b/test/util/index.js
@@ -73,7 +73,15 @@ function getAppConfig(modules = {}) {
           _topics: {
             label: 'Topics',
             type: 'relationship',
-            withType: 'topic'
+            withType: 'topic',
+            builders: {
+              project: {
+                title: 1,
+                image: 1,
+                main: 1,
+                aposMode: 1
+              }
+            }
           },
           main: {
             label: '',

--- a/test/util/index.js
+++ b/test/util/index.js
@@ -74,6 +74,15 @@ function getAppConfig(modules = {}) {
             label: 'Topics',
             type: 'relationship',
             withType: 'topic'
+          },
+          main: {
+            label: '',
+            type: 'area',
+            options: {
+              widgets: {
+                '@apostrophecms/image': {}
+              }
+            }
           }
         }
       }

--- a/test/util/index.js
+++ b/test/util/index.js
@@ -237,6 +237,7 @@ async function insertPiecesAndPages(apos) {
     jar
   });
 
+  console.log('image1', image1);
   await apos.page.insert(req, '_home', 'lastChild', {
     ...pageInstance,
     title: 'page1',

--- a/ui/apos/components/AposExportModal.vue
+++ b/ui/apos/components/AposExportModal.vue
@@ -229,7 +229,7 @@ export default {
       this.relatedTypes = await apos.http.get('/api/v1/@apostrophecms/import-export/related', {
         busy: true,
         qs: {
-          type: this.type
+          types: [ this.type ]
         }
       });
       this.checkedRelatedTypes = this.relatedTypes;


### PR DESCRIPTION
[PRO-6416](https://linear.app/apostrophecms/issue/PRO-6416/related-documents-are-missing-fields-because-they-are-taken-directly)

## Summary

* Uses the method `findForEditing` to get related documents instead of taking them directly from exported docs. This way data exported isn't limited to projections.
* The `related` routes, also checks related types of related types. Ex: if your exported piece is an article with relations to images, before the related modal wouldn't have proposed `image-tag` (relation of images) now it does.

## What are the specific steps to test this change?

* Related modal should should also show the related types of the exported document related documents. Still have a recursion level limit of 10 (that is probably useless).

* Let's say you have articles and topics.
Topics has projections.
Export an article with a relation to a topic.
It should export the entire topic not only projected fields

[Cypress tests](https://github.com/apostrophecms/testbed/actions/runs/10577507149): 🟠 

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
