### PR TITLE
do not try to replace existing attachments, just merge crops and use recomputeAllDocReferences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ node_modules
 
 # vim swp files
 .*.sw*
+/test/public/uploads
+/test/public/exports

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -166,6 +166,9 @@ module.exports = self => {
         });
       }
 
+      // One call to fix all bookkeeping re: docIds, archivedDocIds, etc.
+      await self.apos.attachment.recomputeAllDocReferences();
+
       const results = {
         overrideLocale,
         duplicatedDocs,
@@ -682,21 +685,26 @@ module.exports = self => {
         }
       }
 
-      try {
+      const existing = await self.apos.attachment.db.findOne({
+        _id: attachment._id
+      });
+      if (!existing) {
         await self.apos.attachment.insert(
           req,
           file,
           { attachmentId: attachment._id }
         );
-      } catch (err) {
-        if (err.message === 'duplicate' && !self.options.preventUpdateAssets) {
-          await self.apos.attachment.update(
-            req,
-            file,
-            attachment
-          );
-        } else {
-          throw err;
+      } else {
+        // Same _id === same original file, same scaled versions, etc.
+        // The only differences will be in the crops and the
+        // docIds etc. We will take care of docIds in one shot later via
+        // recomputeAllDocReferences
+        //
+        // Perform any crops not found in the existing attachment
+        for (const crop of [ ...(attachment.crops || []), ...(existing.crops || []) ]) {
+          if (!existing.crops.find(c => JSON.stringify(c) === JSON.stringify(crop))) {
+            await self.apos.attachment.crop(req, attachment._id, crop);
+          }
         }
       }
     },

--- a/test/index.js
+++ b/test/index.js
@@ -434,9 +434,9 @@ describe('@apostrophecms/import-export', function () {
         'topic2',
         'topic1'
       ],
-      attachmentNames: [ 'test-image' ],
+      attachmentNames: [ 'new-name' ],
       attachmentFileNames: new Array(apos.attachment.imageSizes.length + 1)
-        .fill('test-image'),
+        .fill('new-name'),
       job: {
         good: 9,
         total: 11
@@ -591,9 +591,9 @@ describe('@apostrophecms/import-export', function () {
         'page1',
         'page1'
       ],
-      attachmentNames: [ 'test-image' ],
+      attachmentNames: [ 'new-name' ],
       attachmentFileNames: new Array(apos.attachment.imageSizes.length + 1)
-        .fill('test-image'),
+        .fill('new-name'),
       job: {
         good: 7,
         total: 7


### PR DESCRIPTION
I think I've dealt with this properly. But I could use some help fixing the tests which are trying to prove that the original file *did* get reuploaded for the same attachment, which is something that actually should not ever happen, since originals are supposed to be immutable. The only parts of an attachment that should ever change are crops and the docIds/archivedDocIds/etc. bookkeeping, which is now dealt with just once at the end by invoking `recomputeAllDocReferences`.

I see that an update method was added to the attachment module, but it was only done for this module's benefit. So if we released it we can deprecate it.
