### PR TITLE
fixed an oversight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 * Fixes SASS warnings.
 * Fixes a bug where related documents were not exported if they were only in one (draft or published) mode.
-* Cleanup timers on instance destroy.
+* Fixes a bug where additional crops of an image were not imported properly when the image was already present on the receiving site.
+* Clean up timers on instance destroy.
 
 ## Changes
 

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -751,8 +751,8 @@ module.exports = self => {
         // recomputeAllDocReferences
         //
         // Perform any crops not found in the existing attachment
-        for (const crop of [ ...(attachment.crops || []), ...(existing.crops || []) ]) {
-          if (!existing.crops.find(c => JSON.stringify(c) === JSON.stringify(crop))) {
+        for (const crop of attachment.crops || []) {
+          if (!(existing.crops || []).find(c => JSON.stringify(c) === JSON.stringify(crop))) {
             await self.apos.attachment.crop(req, attachment._id, crop);
           }
         }


### PR DESCRIPTION
This clears up a scenario Lindsay spotted: if the image exists on the destination site due to a previous import but had no crops yet at that point, its crops property won't be an array yet, resulting in an error when attempting to merge in a crop of that image as part of a new import later. I will make sure Lindsay retests.