### PR TITLE
PRO-6870 Export Templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 * Pages linked a page via the "Internal Page" option in the rich text editor are now candidates to be exported as related documents.
 * Images embedded inline in rich text widgets via the `insert: [ 'image' ]` option are now candidates to be exported as related documents.
+* Uses `moduleLabels` prop when available.
+
+### Fixes
+
+* Fixes Export modal related types slide animation. Uses `checkedTypes` when passed from parent component.
 
 ## 2.5.0 (2024-11-08)
 

--- a/ui/apos/components/AposExportModal.vue
+++ b/ui/apos/components/AposExportModal.vue
@@ -151,7 +151,7 @@ export default {
     },
     checkedTypes: {
       type: Array,
-      default: () => []
+      default: null
     },
     doc: {
       type: Object,
@@ -164,6 +164,10 @@ export default {
     messages: {
       type: Object,
       default: () => ({})
+    },
+    moduleLabels: {
+      type: Object,
+      default: null
     }
   },
 
@@ -190,10 +194,10 @@ export default {
 
   computed: {
     moduleLabel() {
-      const moduleOptions = apos.modules[this.moduleName];
+      const labels = this.moduleLabels || apos.modules[this.moduleName];
       const label = this.count > 1
-        ? moduleOptions.pluralLabel
-        : moduleOptions.label;
+        ? labels.pluralLabel
+        : labels.label;
 
       return this.$t(label).toLowerCase();
     },

--- a/ui/apos/components/AposExportModal.vue
+++ b/ui/apos/components/AposExportModal.vue
@@ -210,9 +210,7 @@ export default {
       }));
     },
     checkedTypesComputed() {
-      return this.moduleName === '@apostrophecms/page' && !this.type
-        ? [ ...new Set(this.checkedTypes) ]
-        : [ this.type ];
+      return this.checkedTypes || [ this.type ];
     }
   },
 

--- a/ui/apos/components/AposExportModal.vue
+++ b/ui/apos/components/AposExportModal.vue
@@ -65,8 +65,8 @@
           </div>
 
           <transition
-            name="fade"
-            :duration="200"
+            name="slide"
+            duration="200"
           >
             <div
               v-show="!relatedDocumentsDisabled"
@@ -137,7 +137,7 @@
 <script>
 const CONTAINER_ITEM_HEIGHT = 24;
 const CONTAINER_DESCRIPTION_HEIGHT = 95;
-const CONTAINER_MINIMUM_HEIGHT = 120;
+const CONTAINER_MINIMUM_HEIGHT = 117;
 
 export default {
   props: {
@@ -244,9 +244,11 @@ export default {
         }
       });
       this.checkedRelatedTypes = this.relatedTypes;
-      const height = this.checkedRelatedTypes.length
+      const height = this.relatedTypes.length
         ? this.checkedRelatedTypes.length * CONTAINER_ITEM_HEIGHT + CONTAINER_DESCRIPTION_HEIGHT
         : CONTAINER_MINIMUM_HEIGHT;
+
+      await this.$nextTick();
       this.$refs.container.style.setProperty('--container-height', `${height}px`);
     },
     async runExport() {
@@ -450,25 +452,15 @@ export default {
   width: 100%;
 }
 
-.fade-enter-active {
-  .apos-export__section-container {
-    animation: expand .3;
-  }
+.apos-export__section-container {
+  height: var(--container-height);
+  transition: height 200ms linear;
 }
 
-.fade-leave-active {
+.slide-enter-from, .slide-leave-to {
   .apos-export__section-container {
-    animation: expand .3 reverse;
-  }
-}
-
-@keyframes expand {
-  0% {
     height: 0;
   }
-
-  100% {
-    height: var(--container-height);
-  }
 }
+
 </style>


### PR DESCRIPTION
[PRO-6871](https://linear.app/apostrophecms/issue/PRO-6871/missing-space-between-templates-and-the-menu-above-it-in-the-template)
[PRO-6870](https://linear.app/apostrophecms/issue/PRO-6870/when-i-try-to-export-a-document-template-from-within-the-templates)

## PRs
- https://github.com/apostrophecms/apostrophe/pull/4834
- https://github.com/apostrophecms/import-export/pull/99
- https://github.com/apostrophecms/doc-template-library/pull/79

## Summary

* Add margin top to grid
* Gets related types in export modal for all checked doc types (and not for the doc template module itself).

## What are the specific steps to test this change?

* There is a nice margin between the manager toolbar and the grid.
* When export batching, the related types you can check should match all the types of templates you checked (and not the related types of the template module).

[Cypress tests](https://github.com/apostrophecms/testbed/actions/runs/12652876783): 🟠 

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
