### PR TITLE
adds method to sort all documents and pages

### DIFF
--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -1,5 +1,5 @@
 
-module.exports = (self) => {
+module.exports = self => {
   return {
     'apostrophe:modulesRegistered': {
       setContextOperations() {

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -92,18 +92,6 @@ module.exports = (self) => {
         })
       );
 
-      for (const {
-        _id, title, aposMode, level, rank
-      } of allDocs) {
-        console.log('doc:', {
-          _id,
-          title,
-          aposMode,
-          level,
-          rank
-        });
-      }
-
       return self.exportFile(
         req,
         reporting,
@@ -158,28 +146,20 @@ module.exports = (self) => {
         return [];
       }
 
-      /* const isPage = self.apos.instanceOf(manager, '@apostrophecms/page'); */
       const { draftIds, publishedIds } = self.getAllModesIds(docsIds);
       const isReqDraft = req.mode === 'draft';
 
       const docs = [];
 
       const draftReq = isReqDraft ? req : req.clone({ mode: 'draft' });
-      const cursor = await manager
+      const draftDocs = await manager
         .findForEditing(draftReq, {
           _id: {
             $in: draftIds
           }
         })
-        .relationships(false);
-
-      /* if (isPage) { */
-      /*   cursor.sort({ */
-      /*     level: 1, */
-      /*     rank: 1 */
-      /*   }); */
-      /* } */
-      const draftDocs = await cursor.toArray();
+        .relationships(false)
+        .toArray();
 
       docs.push(...draftDocs);
 

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -7,7 +7,7 @@ const { uniqBy, uniqueId } = require('lodash');
 
 const MAX_RECURSION = 10;
 
-module.exports = (self) => {
+module.exports = self => {
   return {
     async export(req, manager, reporting = null) {
       if (!req.user) {

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -107,6 +107,12 @@ module.exports = (self) => {
 
     sortDocs(docs) {
       docs.sort((a, b) => {
+        if (a.aposMode === 'draft' && b.aposMode === 'published') {
+          return -1;
+        }
+        if (a.aposMode === 'published' && b.aposMode === 'draft') {
+          return 1;
+        }
         if (!self.apos.page.isPage(a) && !self.apos.page.isPage(b)) {
           return 0;
         }
@@ -114,12 +120,6 @@ module.exports = (self) => {
           return -1;
         }
         if (!self.apos.page.isPage(a) && self.apos.page.isPage(b)) {
-          return 1;
-        }
-        if (a.aposMode === 'draft' && b.aposMode === 'published') {
-          return -1;
-        }
-        if (a.aposMode === 'published' && b.aposMode === 'draft') {
           return 1;
         }
         if (a.level > b.level) {

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -142,6 +142,11 @@ module.exports = (self) => {
     // so that we can retrieve their relationships IDs later,
     // and to let the manager handle permissions.
     async getDocs(req, docsIds, manager, reporting) {
+      // For BC, used to accept hasRelatedTypes as third param
+      if (arguments.length === 5) {
+        manager = arguments[3];
+        reporting = arguments[4];
+      }
       if (!docsIds.length) {
         return [];
       }

--- a/lib/methods/export.js
+++ b/lib/methods/export.js
@@ -7,7 +7,7 @@ const { uniqBy, uniqueId } = require('lodash');
 
 const MAX_RECURSION = 10;
 
-module.exports = self => {
+module.exports = (self) => {
   return {
     async export(req, manager, reporting = null) {
       if (!req.user) {
@@ -33,9 +33,11 @@ module.exports = self => {
 
       const hasRelatedTypes = !!relatedTypes.length;
 
-      const docs = (await self.getDocs(req, ids, hasRelatedTypes, manager, reporting))
+      const docs = (await self.getDocs(req, ids, manager, reporting))
         .map((doc) => self.apos.util.clonePermanent(doc));
+
       if (!hasRelatedTypes) {
+        self.sortDocs(docs);
         return self.exportFile(
           req,
           reporting,
@@ -54,6 +56,8 @@ module.exports = self => {
           storedData: allDocs
         });
       }
+
+      self.sortDocs(allDocs);
 
       if (!format.includeAttachments) {
         return self.exportFile(
@@ -88,6 +92,18 @@ module.exports = self => {
         })
       );
 
+      for (const {
+        _id, title, aposMode, level, rank
+      } of allDocs) {
+        console.log('doc:', {
+          _id,
+          title,
+          aposMode,
+          level,
+          rank
+        });
+      }
+
       return self.exportFile(
         req,
         reporting,
@@ -101,28 +117,69 @@ module.exports = self => {
       );
     },
 
+    sortDocs(docs) {
+      docs.sort((a, b) => {
+        if (!self.apos.page.isPage(a) && !self.apos.page.isPage(b)) {
+          return 0;
+        }
+        if (self.apos.page.isPage(a) && !self.apos.page.isPage(b)) {
+          return -1;
+        }
+        if (!self.apos.page.isPage(a) && self.apos.page.isPage(b)) {
+          return 1;
+        }
+        if (a.aposMode === 'draft' && b.aposMode === 'published') {
+          return -1;
+        }
+        if (a.aposMode === 'published' && b.aposMode === 'draft') {
+          return 1;
+        }
+        if (a.level > b.level) {
+          return 1;
+        }
+        if (a.level < b.level) {
+          return -1;
+        }
+        if (a.rank < b.rank) {
+          return -1;
+        }
+        if (a.rank > b.rank) {
+          return 1;
+        }
+        return 0;
+      });
+    },
+
     // Get docs via their manager in order to populate them
     // so that we can retrieve their relationships IDs later,
     // and to let the manager handle permissions.
-    async getDocs(req, docsIds, includeRelationships, manager, reporting) {
+    async getDocs(req, docsIds, manager, reporting) {
       if (!docsIds.length) {
         return [];
       }
 
+      /* const isPage = self.apos.instanceOf(manager, '@apostrophecms/page'); */
       const { draftIds, publishedIds } = self.getAllModesIds(docsIds);
       const isReqDraft = req.mode === 'draft';
 
       const docs = [];
 
       const draftReq = isReqDraft ? req : req.clone({ mode: 'draft' });
-      const draftDocs = await manager
+      const cursor = await manager
         .findForEditing(draftReq, {
           _id: {
             $in: draftIds
           }
         })
-        .relationships(includeRelationships)
-        .toArray();
+        .relationships(false);
+
+      /* if (isPage) { */
+      /*   cursor.sort({ */
+      /*     level: 1, */
+      /*     rank: 1 */
+      /*   }); */
+      /* } */
+      const draftDocs = await cursor.toArray();
 
       docs.push(...draftDocs);
 
@@ -133,7 +190,7 @@ module.exports = self => {
             $in: publishedIds
           }
         })
-        .relationships(includeRelationships)
+        .relationships(false)
         .toArray();
 
       docs.push(...publishedDocs);
@@ -225,7 +282,7 @@ module.exports = self => {
         if (!field.withType && !fieldValue) {
           continue;
         }
-        if (field.withType && relatedTypes && !relatedTypesIncludes(field.withType)) {
+        if (field.withType && relatedTypes && !self.relatedTypesIncludes(field.withType, relatedTypes)) {
           continue;
         }
         if (field.withType && !self.canExport(req, field.withType)) {
@@ -290,16 +347,16 @@ module.exports = self => {
           });
         }
       }
+    },
 
-      function relatedTypesIncludes(name) {
-        if ([ '@apostrophecms/any-page-type', '@apostrophecms/page' ].includes(name)) {
-          return relatedTypes.some(type => {
-            const module = self.apos.modules[type];
-            return self.apos.instanceOf(module, '@apostrophecms/page-type');
-          });
-        }
-        return relatedTypes.includes(name);
+    relatedTypesIncludes(name, relatedTypes) {
+      if ([ '@apostrophecms/any-page-type', '@apostrophecms/page' ].includes(name)) {
+        return relatedTypes.some(type => {
+          const module = self.apos.modules[type];
+          return self.apos.instanceOf(module, '@apostrophecms/page-type');
+        });
       }
+      return relatedTypes.includes(name);
     },
 
     async getRelatedDocsFromRichTextWidget(req, {

--- a/test/index.js
+++ b/test/index.js
@@ -156,6 +156,18 @@ describe('@apostrophecms/import-export', function () {
           aposMode: 'draft'
         },
         {
+          title: 'topic1',
+          aposMode: 'draft'
+        },
+        {
+          title: 'topic3',
+          aposMode: 'draft'
+        },
+        {
+          title: 'topic2',
+          aposMode: 'draft'
+        },
+        {
           title: 'article2',
           aposMode: 'published'
         },
@@ -164,24 +176,12 @@ describe('@apostrophecms/import-export', function () {
           aposMode: 'published'
         },
         {
-          title: 'topic1',
-          aposMode: 'draft'
-        },
-        {
-          title: 'topic3',
-          aposMode: 'draft'
-        },
-        {
           title: 'topic3',
           aposMode: 'published'
         },
         {
           title: 'topic1',
           aposMode: 'published'
-        },
-        {
-          title: 'topic2',
-          aposMode: 'draft'
         },
         {
           title: 'topic2',
@@ -287,6 +287,10 @@ describe('@apostrophecms/import-export', function () {
           aposMode: 'draft'
         },
         {
+          title: 'topic2',
+          aposMode: 'draft'
+        },
+        {
           title: 'article2',
           aposMode: 'published'
         },
@@ -296,13 +300,8 @@ describe('@apostrophecms/import-export', function () {
         },
         {
           title: 'topic2',
-          aposMode: 'draft'
-        },
-        {
-          title: 'topic2',
           aposMode: 'published'
         }
-
       ],
       attachmentsLength: 1,
       attachmentFiles: [ `${attachmentId}-test-image.jpg` ],
@@ -350,24 +349,24 @@ describe('@apostrophecms/import-export', function () {
           aposMode: 'draft'
         },
         {
+          title: 'image1',
+          aposMode: 'draft'
+        },
+        {
+          title: 'article2',
+          aposMode: 'draft'
+        },
+        {
           title: 'page1',
           aposMode: 'published'
         },
         {
           title: 'image1',
-          aposMode: 'draft'
-        },
-        {
-          title: 'image1',
           aposMode: 'published'
         },
         {
           title: 'article2',
           aposMode: 'published'
-        },
-        {
-          title: 'article2',
-          aposMode: 'draft'
         }
       ],
       attachmentsLength: 1,
@@ -1641,5 +1640,154 @@ describe('@apostrophecms/import-export', function () {
       assert.equal(pages[1].aposMode, 'published');
       assert.equal(pages[1].main.items[0].content, '<p><em>rich</em> <strong>text</strong> - edited</p>');
     });
+
+    it('should sort all exported documents', async function() {
+      const docs = [
+        {
+          title: 'doc1',
+          aposMode: 'draft'
+        },
+
+        {
+          title: 'sub2',
+          aposMode: 'published',
+          level: 2,
+          rank: 1,
+          slug: '/'
+        },
+        {
+          title: 'sub2 bis',
+          aposMode: 'published',
+          level: 2,
+          rank: 2,
+          slug: '/'
+        },
+
+        {
+          title: 'sub2 bis',
+          aposMode: 'draft',
+          level: 2,
+          rank: 2,
+          slug: '/'
+        },
+
+        {
+          title: 'sub2',
+          aposMode: 'draft',
+          level: 2,
+          rank: 1,
+          slug: '/'
+        },
+        {
+          title: 'doc1',
+          aposMode: 'published'
+        },
+        {
+          title: 'sub sub1 bis',
+          aposMode: 'draft',
+          level: 3,
+          rank: 2,
+          slug: '/'
+        },
+        {
+          title: 'doc3',
+          aposMode: 'draft'
+        },
+        {
+          title: 'sub sub1',
+          aposMode: 'draft',
+          level: 3,
+          rank: 1,
+          slug: '/'
+        },
+        {
+          title: 'sub sub1',
+          aposMode: 'published',
+          level: 3,
+          rank: 1,
+          slug: '/'
+        },
+        {
+          title: 'doc3',
+          aposMode: 'published'
+        },
+        {
+          title: 'sub sub1 bis',
+          aposMode: 'published',
+          level: 3,
+          rank: 2,
+          slug: '/'
+        },
+        {
+          title: 'doc2',
+          aposMode: 'published'
+        },
+        {
+          title: 'doc2',
+          aposMode: 'draft'
+        },
+        {
+          title: 'sub1',
+          aposMode: 'published',
+          level: 2,
+          rank: 1,
+          slug: '/'
+        },
+        {
+          title: 'parent2',
+          aposMode: 'published',
+          level: 1,
+          rank: 2,
+          slug: '/'
+        },
+        {
+          title: 'sub1',
+          aposMode: 'draft',
+          level: 2,
+          rank: 1,
+          slug: '/'
+        },
+        {
+          title: 'parent1',
+          aposMode: 'published',
+          level: 1,
+          rank: 1,
+          slug: '/'
+        },
+        {
+          title: 'parent1',
+          aposMode: 'draft',
+          level: 1,
+          rank: 1,
+          slug: '/'
+        },
+
+        {
+          title: 'parent2',
+          aposMode: 'draft',
+          level: 1,
+          rank: 2,
+          slug: '/'
+        }
+      ];
+      importExportManager.sortDocs(docs);
+
+      const actual = docs.map(({ title, aposMode }) => `${title}:${aposMode}`);
+      const expected = [
+        'parent1:draft', 'parent2:draft',
+        'sub2:draft', 'sub1:draft',
+        'sub2 bis:draft', 'sub sub1:draft',
+        'sub sub1 bis:draft', 'doc1:draft',
+        'doc3:draft', 'doc2:draft',
+        'parent1:published', 'parent2:published',
+        'sub2:published', 'sub1:published',
+        'sub2 bis:published', 'sub sub1:published',
+        'sub sub1 bis:published', 'doc1:published',
+        'doc3:published', 'doc2:published'
+      ];
+
+      assert.deepEqual(actual, expected);
+    });
+
   });
 });


### PR DESCRIPTION
[PRO-6827](https://linear.app/apostrophecms/issue/PRO-6827/page-hierarchy-must-be-respected)

## Summary

Fixes page hierarchy not being respected during import.
Sort exported documents as well as their related documents.

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
