### PR TITLE
makes progress notification client only

### DIFF
--- a/ui/apos/components/AposImportModal.vue
+++ b/ui/apos/components/AposImportModal.vue
@@ -218,6 +218,7 @@ export default {
 
       const notifId = await apos.notify('apostrophe:uploading', {
         type: 'progress',
+        clientOnly: true,
         icon: 'cloud-upload-icon',
         interpolate: {
           name: this.selectedFile.name


### PR DESCRIPTION
Tiny fix to avoid empty progress notification to appear to other users.