### PR TITLE
passes needed informations to batch operation job, no refresh for export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 * Better english wording when import succeeds.
+* Adds missing information to export and import batch operation jobs.
 
 ## 3.0.0 (2025-02-19)
 

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -106,10 +106,10 @@ module.exports = self => {
       }
 
       const total = docs.length + attachmentsInfo.length;
-
+      const idsAndTypes = self.getIdsAndTypes(docs);
       const {
         reporting, jobId, notificationId
-      } = await self.instantiateJob(req, total);
+      } = await self.instantiateJob(req, total, idsAndTypes);
 
       const failedIds = [];
       const failedLog = {};
@@ -214,7 +214,7 @@ module.exports = self => {
       return results;
     },
 
-    async instantiateJob(req, total) {
+    async instantiateJob(req, total, { ids, types }) {
       const jobManager = self.apos.modules['@apostrophecms/job'];
       const job = await jobManager.start();
 
@@ -222,7 +222,10 @@ module.exports = self => {
         icon: 'database-import-icon',
         type: 'success',
         job: {
-          _id: job._id
+          _id: job._id,
+          ids,
+          action: 'import',
+          docTypes: [ ...types ]
         },
         return: true
       });
@@ -1191,6 +1194,24 @@ module.exports = self => {
       }
 
       return doc;
+    },
+
+    getIdsAndTypes(docs) {
+      return docs.reduce((acc, doc) => {
+        acc.ids.push(doc._id);
+
+        const manager = self.apos.doc.getManager(doc.type);
+        if (self.isPage(manager)) {
+          acc.types.add('@apostrophecms/page');
+        } else {
+          acc.types.add(doc.type);
+        }
+
+        return acc;
+      }, {
+        ids: [],
+        types: new Set()
+      });
     }
   };
 };

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -1203,9 +1203,8 @@ module.exports = self => {
         const manager = self.apos.doc.getManager(doc.type);
         if (self.isPage(manager)) {
           acc.types.add('@apostrophecms/page');
-        } else {
-          acc.types.add(doc.type);
         }
+        acc.types.add(doc.type);
 
         return acc;
       }, {

--- a/modules/@apostrophecms/import-export-page/index.js
+++ b/modules/@apostrophecms/import-export-page/index.js
@@ -74,7 +74,11 @@ module.exports = {
           return self.apos.modules['@apostrophecms/job'].run(
             req,
             (req, reporting) => self.apos.modules['@apostrophecms/import-export']
-              .export(req, self, reporting)
+              .export(req, self, reporting),
+            {
+              action: 'export',
+              docTypes: []
+            }
           );
         }
       }

--- a/modules/@apostrophecms/import-export-page/index.js
+++ b/modules/@apostrophecms/import-export-page/index.js
@@ -77,6 +77,7 @@ module.exports = {
               .export(req, self, reporting),
             {
               action: 'export',
+              ids: req.body._ids,
               docTypes: []
             }
           );

--- a/modules/@apostrophecms/import-export-piece-type/index.js
+++ b/modules/@apostrophecms/import-export-piece-type/index.js
@@ -79,7 +79,11 @@ module.exports = {
             return self.apos.modules['@apostrophecms/job'].run(
               req,
               (req, reporting) => self.apos.modules['@apostrophecms/import-export']
-                .export(req, self, reporting)
+                .export(req, self, reporting),
+              {
+                action: 'export',
+                docTypes: []
+              }
             );
           }
         }

--- a/modules/@apostrophecms/import-export-piece-type/index.js
+++ b/modules/@apostrophecms/import-export-piece-type/index.js
@@ -82,6 +82,7 @@ module.exports = {
                 .export(req, self, reporting),
               {
                 action: 'export',
+                ids: req.body._ids,
                 docTypes: []
               }
             );


### PR DESCRIPTION
[PRO-7017](https://linear.app/apostrophecms/issue/PRO-7017/[media-library]-as-an-editor-i-should-be-able-to-select-multiple)

## Summary

Add needed informations to import and export jobs. (`ids` and `docTypes`).

## What are the specific steps to test this change?

Core gets `docIds` and `docTypes` in `content-changed` events.

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
