### PR TITLE
Pro 7534 recompute doc refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Fix "include related documents" modal height.
 * Fixes `moduleLabel` computed.
+* Fixes missing call to `recomputeAllDocReferences` when duplicated have been overridden.
 
 ### Changes
 

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -180,6 +180,9 @@ module.exports = self => {
           });
 
         await self.remove(exportPath);
+
+        // One call to fix all bookkeeping re: docIds, archivedDocIds, etc.
+        await self.apos.attachment.recomputeAllDocReferences();
         return;
       }
 
@@ -189,9 +192,6 @@ module.exports = self => {
       await self.updateJobResults(jobId, {
         failedLog: logs
       });
-
-      // One call to fix all bookkeeping re: docIds, archivedDocIds, etc.
-      await self.apos.attachment.recomputeAllDocReferences();
 
       const results = {
         importDraftsOnly,
@@ -1127,6 +1127,8 @@ module.exports = self => {
         failedLog: logs
       });
 
+      // One call to fix all bookkeeping re: docIds, archivedDocIds, etc.
+      await self.apos.attachment.recomputeAllDocReferences();
       if (logs.length) {
         await self.apos.notify(req, 'aposImportExport:importFailedForSome', {
           interpolate: {


### PR DESCRIPTION
https://linear.app/apostrophecms/issue/PRO-7534/[import-export]-potential-bad-use-of-recomputealldocreferences