### PR TITLE
show failed imports report when cancelling the override duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Fixes
+
+* Fixes the missing failed imports report modal when cancelling the import during override duplicates phase.
+
 ## 3.2.0 (2025-04-16)
 
 ### Adds

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -1176,12 +1176,31 @@ module.exports = self => {
       if (jobId) {
         const jobManager = self.apos.modules['@apostrophecms/job'];
         try {
-          await jobManager.db.updateOne({ _id: jobId }, {
+          const job = await jobManager.db.findOneAndUpdate({ _id: jobId }, {
             $set: {
               ended: true,
               status: 'completed'
             }
           });
+
+          const failedLogs = job?.results?.failedLog || {};
+          const logs = Object.values(failedLogs);
+          if (logs.length) {
+            await self.apos.notify(req, 'aposImportExport:importFailedForSome', {
+              interpolate: {
+                count: logs.length
+              },
+              dismiss: true,
+              icon: 'database-import-icon',
+              type: 'danger',
+              event: {
+                name: 'import-export-import-ended',
+                data: {
+                  failedLog: logs
+                }
+              }
+            });
+          }
         } catch (err) {
           self.apos.util.error(err);
         }

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -1183,12 +1183,11 @@ module.exports = self => {
             }
           });
 
-          const failedLogs = job?.results?.failedLog || {};
-          const logs = Object.values(failedLogs);
-          if (logs.length) {
+          const failedLog = Object.values(job?.results?.failedLog || {});
+          if (failedLog.length) {
             await self.apos.notify(req, 'aposImportExport:importFailedForSome', {
               interpolate: {
-                count: logs.length
+                count: failedLog.length
               },
               dismiss: true,
               icon: 'database-import-icon',
@@ -1196,7 +1195,7 @@ module.exports = self => {
               event: {
                 name: 'import-export-import-ended',
                 data: {
-                  failedLog: logs
+                  failedLog
                 }
               }
             });


### PR DESCRIPTION
[PRO-7562](https://linear.app/apostrophecms/issue/PRO-7562/[import-export]-error-reporting-doesnt-show-when-cancelling-import)

## Summary

Show failed imports report modal when cancelling the import during override duplicates step.

## What are the specific steps to test this change?

Force code the fail during insert
when the overrides duplicates modal is showed click on cancel (or escape)
the report modal should be showed, the same way it would have if you continue the import


## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
