### PR TITLE
PRO-8169 CSV imports should not require a type column when importing pieces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Fixes
+
+* CSV imports should not require a `type` column when importing pieces.
+
 ## 3.3.0 (2025-08-06)
 
 ### Adds

--- a/lib/methods/import.js
+++ b/lib/methods/import.js
@@ -52,6 +52,13 @@ module.exports = self => {
 
           await self.setExportPathId(exportPath);
         }
+        // CSV and similar formats usually won't have a type column. For pieces,
+        // this should not cause the import to fail
+        if (moduleName && (moduleName !== '@apostrophecms/page')) {
+          for (const doc of docs) {
+            doc.type = doc.type || moduleName;
+          }
+        }
       } catch (error) {
         const [ errKey, type ] = !format && (file?.type || formatLabel)
           ? [ 'aposImportExport:unsupportedFileType', file?.type || formatLabel ]

--- a/test/importDraftsOnly.js
+++ b/test/importDraftsOnly.js
@@ -298,6 +298,31 @@ describe('#import - when `importDraftsOnly` option is set to `true`', function (
           assert.equal(topics[0].lastPublishedAt, undefined);
         });
 
+        it('should import a piece from a csv file without a type column, as long as the module name is known', async function() {
+          importExportManager.formats.csv.input = async () => {
+            return {
+              docs: [
+                {
+                  // type intentionally omitted
+                  title: 'topic1'
+                }
+              ]
+            };
+          };
+
+          await importExportManager.import(req, 'topic');
+
+          const topics = await apos.doc.db
+            .find({ type: 'topic' })
+            .toArray();
+
+          assert.equal(topics.length, 1);
+          assert.equal(topics[0]._id.endsWith(':en:draft'), true);
+          assert.equal(topics[0].aposMode, 'draft');
+          assert.equal(topics[0].aposLocale, 'en:draft');
+          assert.equal(topics[0].title, 'topic1');
+        });
+
         it('should import a page from a csv file that was not made from the import-export module, as draft only', async function() {
           importExportManager.formats.csv.input = async () => {
             return {

--- a/test/index.js
+++ b/test/index.js
@@ -1116,6 +1116,34 @@ describe('@apostrophecms/import-export', function () {
       assert.equal(topics[0].main.items[0].content, '<p><em>rich</em> <strong>text</strong></p>');
     });
 
+    it('should import a piece from a csv file with no type, as long as the module name is known', async function() {
+      csv.input = async () => {
+        return {
+          docs: [
+            {
+              // type intentionally omitted
+              title: 'topic1',
+              description: 'description1',
+              main: '<p><em>rich</em> <strong>text</strong></p>'
+            }
+          ]
+        };
+      };
+
+      await importExportManager.import(getImportReq(), 'topic');
+
+      const topics = await apos.doc.db
+        .find({ type: 'topic' })
+        .toArray();
+
+      assert.equal(topics.length, 1);
+      assert.equal(topics[0].title, 'topic1');
+      assert.equal(topics[0].slug, 'topic1');
+      assert.equal(topics[0].aposMode, 'draft');
+      assert.equal(topics[0].description, 'description1');
+      assert.equal(topics[0].main.items[0].content, '<p><em>rich</em> <strong>text</strong></p>');
+    });
+
     it('should import a page from a csv file that was not made from the import-export module', async function() {
       csv.input = async () => {
         return {


### PR DESCRIPTION
If a CSV shows up with no type column, use the name of the module whose import button was clicked. I needed this in order to import a customer's redirects without creating a gratuitous "type" column.