### PR TITLE
add failed export batch notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## UNRELEASED
+
+### Adds
+
+* Adds failed export batch notifications.
+
 ## 3.4.0 (2025-10-30)
 
 ### Changes

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -13,6 +13,8 @@
   "exportModalRelatedDocumentDescription": "Die folgenden Dokumenttypen bei Bedarf einbeziehen",
   "exportModalSettingsLabel": "Exporteinstellungen",
   "exported": "Exportiert {{ count }} {{ type }}",
+  "exportedFailed": "Export von {{ type }} fehlgeschlagen",
+  "exportedWithFailures": "Exportiert {{ count }} {{ type }} ({{ bad }} von {{ total }} fehlgeschlagen)",
   "exporting": "Exportiere {{ type }}...",
   "import": "Importiere {{ type }}",
   "importCleanFailed": "Die Bereinigung der importierten Datei auf dem Server ist fehlgeschlagen.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -16,6 +16,8 @@
   "exportModalSettingsLabel": "Export Settings",
   "exportModalToggleAllRelated": "Toggle all",
   "exported": "Exported {{ count }} {{ type }}",
+  "exportedFailed": "Exporting {{ type }} failed",
+  "exportedWithFailures": "Exported {{ count }} {{ type }} ({{ bad }} of {{ total }} failed)",
   "exporting": "Exporting {{ type }}...",
   "import": "Import {{ type }}",
   "importCleanFailed": "The cleaning of the imported file on the server failed.",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -13,6 +13,8 @@
   "exportModalRelatedDocumentDescription": "Incluir los siguientes tipos de documentos donde sea aplicable",
   "exportModalSettingsLabel": "Configuraciones de Exportación",
   "exported": "Exportado {{ count }} {{ type }}",
+  "exportedFailed": "Error al exportar {{ type }}",
+  "exportedWithFailures": "Exportado {{ count }} {{ type }} ({{ bad }} de {{ total }} fallaron)",
   "exporting": "Exportando {{ type }}...",
   "import": "Importar {{ type }}",
   "importCleanFailed": "La limpieza del archivo importado en el servidor falló.",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -13,6 +13,8 @@
   "exportModalRelatedDocumentDescription": "Inclure les types de documents suivants le cas échéant",
   "exportModalSettingsLabel": "Paramètres d'exportation",
   "exported": "Exporté {{ count }} {{ type }}",
+  "exportedFailed": "L'exportation de {{ type }} a échoué",
+  "exportedWithFailures": "Exporté {{ count }} {{ type }} ({{ bad }} sur {{ total }} ont échoué)",
   "exporting": "Exportation de {{ type }}...",
   "import": "Importer {{ type }}",
   "importCleanFailed": "Le nettoyage du fichier importé sur le serveur a échoué.",

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -13,6 +13,8 @@
   "exportModalRelatedDocumentDescription": "Includi i seguenti tipi di documento dove applicabile",
   "exportModalSettingsLabel": "Impostazioni di esportazione",
   "exported": "Esportati {{ count }} {{ type }}",
+  "exportedFailed": "Esportazione di {{ type }} non riuscita",
+  "exportedWithFailures": "Esportati {{ count }} {{ type }} ({{ bad }} di {{ total }} non riusciti)",
   "exporting": "Esportazione {{ type }}...",
   "import": "Importa {{ type }}",
   "importCleanFailed": "La pulizia del file importato sul server è fallita.",

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -13,6 +13,8 @@
   "exportModalRelatedDocumentDescription": "Incluir os seguintes tipos de documentos onde aplicável",
   "exportModalSettingsLabel": "Configurações de Exportação",
   "exported": "Exportados {{ count }} {{ type }}",
+  "exportedFailed": "Falha ao exportar {{ type }}",
+  "exportedWithFailures": "Exportados {{ count }} {{ type }} ({{ bad }} de {{ total }} falharam)",
   "exporting": "Exportando {{ type }}...",
   "import": "Importar {{ type }}",
   "importCleanFailed": "A limpeza do arquivo importado no servidor falhou.",

--- a/i18n/sk.json
+++ b/i18n/sk.json
@@ -13,6 +13,8 @@
   "exportModalRelatedDocumentDescription": "Zahrnúť nasledujúce typy dokumentov tam, kde je to relevantné",
   "exportModalSettingsLabel": "Nastavenia exportu",
   "exported": "Exportované {{ count }} {{ type }}",
+  "exportedFailed": "Exportovanie {{ type }} zlyhalo",
+  "exportedWithFailures": "Exportované {{ count }} {{ type }} ({{ bad }} z {{ total }} zlyhalo)",
   "exporting": "Exportovanie {{ type }}...",
   "import": "Importovať {{ type }}",
   "importCleanFailed": "Údržba importovaného súboru na serveri zlyhala.",

--- a/modules/@apostrophecms/import-export-page/index.js
+++ b/modules/@apostrophecms/import-export-page/index.js
@@ -31,6 +31,8 @@ module.exports = {
           messages: {
             progress: 'aposImportExport:exporting',
             completed: 'aposImportExport:exported',
+            completedWithFailures: 'aposImportExport:exportedWithFailures',
+            failed: 'aposImportExport:exportedFailed',
             icon: 'database-export-icon',
             resultsEventName: 'import-export-export-download'
           },

--- a/modules/@apostrophecms/import-export-piece-type/index.js
+++ b/modules/@apostrophecms/import-export-piece-type/index.js
@@ -31,6 +31,8 @@ module.exports = {
           messages: {
             progress: 'aposImportExport:exporting',
             completed: 'aposImportExport:exported',
+            completedWithFailures: 'aposImportExport:exportedWithFailures',
+            failed: 'aposImportExport:exportedFailed',
             icon: 'database-export-icon',
             resultsEventName: 'import-export-export-download'
           },


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Add failure notifications to batch operation

## What are the specific steps to test this change?

You need https://github.com/apostrophecms/apostrophe/pull/5157 to test this.

1. Use a batch operation that that fails totally or only for some of the run.
2. Check the frontend notification

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [x] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [x] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
